### PR TITLE
Fix RNG service loading sequence in index.html

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
@@ -1,5 +1,5 @@
 # Game Version History
-Last updated: 2025-10-03 21:20 UTC
+Last updated: 2025-10-06 00:00 UTC
 
 This file tracks notable changes to the game across iterations. Versions here reflect functional milestones rather than semantic releases.
 
@@ -9,6 +9,23 @@ Conventions
 - Fixed: bug fixes
 - UI: user interface-only changes
 - Dev: refactors, tooling, or internal changes
+
+v1.18 — Click-to-loot containers and canvas click support
+- Added: Precise click-to-loot in dungeon
+  - core/game.js: clicking a chest/corpse tile now targets that specific container.
+    - If standing on it: loots immediately.
+    - If adjacent: takes one step onto the container, then auto-loots.
+    - If farther away: shows a hint to move next to the container first.
+- Changed: Canvas click QoL
+  - core/game.js: adjacent tile clicks move one step (dungeon and town).
+  - Town: clicking your own tile triggers the context action (talk/exit/loot underfoot), unchanged.
+- Dev: Clicks are ignored while inventory/loot/GOD panels are open to avoid accidental actions.
+
+v1.17 — Deterministic RNG init order hardening
+- Changed: index.html loads core/rng_service.js immediately after core/ctx.js.
+  - Ensures all subsequently loaded modules bind to the centralized RNG service rather than constructing fallbacks.
+  - Removed later duplicate RNG load position (no behavior change intended beyond initialization timing).
+- Dev: No data migrations required; determinism preserved across seeds.
 
 v1.16 — More dungeons, spawn near dungeon, and smoke test auto-routes/loots
 - Changed: Increased dungeon density and terrain bias

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
@@ -131,6 +131,8 @@
     })();
   </script>
   <script src="core/ctx.js"></script>
+  <!-- Load central RNG service early so all following modules can bind to it deterministically -->
+  <script src="core/rng_service.js"></script>
   <script src="world/world.js"></script>
   <script src="world/los.js"></script>
   <script src="entities/enemies.js"></script>
@@ -148,8 +150,6 @@
   <script src="entities/player_utils.js"></script>
   <script src="entities/player_equip.js"></script>
   <script src="entities/player.js"></script>
-  <!-- Central RNG service must load before items/game to avoid duplicate PRNG implementations -->
-  <script src="core/rng_service.js"></script>
   <script src="services/time_service.js"></script>
   <script src="entities/items.js"></script>
   <script src="dungeon/dungeon_items.js"></script>


### PR DESCRIPTION
This PR modifies the loading sequence of scripts in the index.html file. Specifically, it moves the loading of the central RNG service (`rng_service.js`) to occur earlier in the order. This ensures that all following modules can bind to the RNG service deterministically, addressing potential issues with duplicate PRNG implementations. The previous placement resulted in incorrect behavior if the RNG service was not initialized before other game elements.

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/xwirib32pff6](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/xwirib32pff6)
Author: zakker111
