### PR TITLE
Fix Syntax Error in loader.js

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
@@ -47,7 +47,7 @@
     town: null,
     flavor: null,
     ready: null,
-  }</;
+  };
 
 
   function logNotice(msg) {


### PR DESCRIPTION
This pull request corrects a syntax error in the loader.js file. The closing bracket was incorrectly formatted as `}</;` and has been updated to `};`. This change ensures proper syntax and functionality in the code, helping to avoid potential runtime errors.

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/ejbs3qt3fl44](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/ejbs3qt3fl44)
Author: zakker111
