### PR TITLE
Fix Syntax Error in loader.js

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
@@ -47,7 +47,7 @@
     town: null,
     flavor: null,
     ready: null,
-  }</;
+  };
 
 
   function logNotice(msg) {


### PR DESCRIPTION
This pull request corrects a syntax error found in the `loader.js` file. The erroneous line has been fixed from an incorrect closing tag to a proper closing brace for the object definition. This change ensures that the code adheres to JavaScript syntax and prevents potential runtime errors.

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/kdxb1iqgo90v](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/kdxb1iqgo90v)
Author: zakker111
