### PR TITLE
Add Seen Life usage tracking for equipped items with UI indicators

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
@@ -27,6 +27,7 @@
 
 import { getTileDef } from "../data/tile_lookup.js";
 import { logFollowerCritTaken, logFollowerCritDealt, logFollowerFlee } from "../core/followers_flavor.js";
+import { incrementSeenLifeUseForArmorSlot } from "../combat/item_buffs.js";
 
 // Reusable direction arrays to avoid per-tick allocations
 const ALT_DIRS = Object.freeze([{ x: -1, y: 0 }, { x: 1, y: 0 }, { x: 0, y: -1 }, { x: 0, y: 1 }]);
@@ -663,6 +664,8 @@ export function enemiesAct(ctx) {
         else if (loc.part === "legs") wear = randFloat(0.4, 1.3, 1);
         else if (loc.part === "hands") wear = randFloat(0.3, 1.0, 1);
         ctx.decayEquipped(loc.part, wear * critWear);
+        // Track armor usage for Seen life buff when the player is hit.
+        incrementSeenLifeUseForArmorSlot(ctx, loc.part);
 
         // Persistent injury tracker (cosmetic role; shown in Character Sheet via F1)
         try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/town_combat.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/town_combat.js
@@ -12,6 +12,7 @@
  */
 
 import { getRNGUtils, getMod } from "../utils/access.js";
+import { incrementSeenLifeUseForArmorSlot } from "../combat/item_buffs.js";
 
 // Local RNG helper (mirrors rngFor in town_ai.js)
 function rngFor(ctx) {
@@ -271,7 +272,9 @@ function banditAttackPlayer(ctx, attacker) {
       } catch (_) {}
       try {
         if (typeof ctx.decayEquipped === "function") {
-          ctx.decayEquipped("hands", randFloat(0.3, 1.0, 1));
+          ctx.decayEquipped(loc.part, wear * critWear);
+          // Track armor usage for Seen life buff when the player is hit in town combat.
+          incrementSeenLifeUseForArmorSlot(ctx, loc.part);
         }
       } catch (_) {}
       return;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/combat/combat.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/combat/combat.js
@@ -15,6 +15,7 @@
  */
 
 import { getRNGUtils, getMod } from "../utils/access.js";
+import { incrementSeenLifeUse } from "./item_buffs.js";
 function round1(ctx, n) {
   if (ctx && ctx.utils && typeof ctx.utils.round1 === "function") return ctx.utils.round1(n);
   return Math.round(n * 10) / 10;
@@ -403,6 +404,23 @@ export function playerAttackEnemy(ctx, enemy) {
     if (cat.twoHanded) p.skills.twoHand += 1;
     else p.skills.oneHand += 1;
     if (cat.blunt) p.skills.blunt += 1;
+  } catch (_) {}
+
+  // Seen life weapon buff: track uses for equipped weapons.
+  try {
+    const p = ctx.player || null;
+    const eq = p && p.equipment ? p.equipment : null;
+    if (eq) {
+      const seenItems = new Set();
+      const slots = ["left", "right", "hands"];
+      for (let i = 0; i < slots.length; i++) {
+        const it = eq[slots[i]];
+        if (!it || typeof it.atk !== "number") continue;
+        if (seenItems.has(it)) continue;
+        seenItems.add(it);
+        incrementSeenLifeUse(ctx, it, "weapon");
+      }
+    }
   } catch (_) {}
 
   // Decay hands after attack

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/combat/item_buffs.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/combat/item_buffs.js
@@ -1,0 +1,168 @@
+/**
+ * ItemBuffs: lightweight item enchantment hooks (e.g., Seen life).
+ *
+ * Exports (ESM + window.ItemBuffs):
+ * - incrementSeenLifeUse(ctx, item, kind)
+ * - incrementSeenLifeUseForArmorSlot(ctx, slot)
+ *
+ * Notes:
+ * - kind is a hint for which stat to buff: "weapon" (attack) or "armor" (defense).
+ * - Uses a per-item counter (_seenLifeUses) so buffs are tied to the specific piece of gear.
+ * - Buff is permanent and applied directly to item.atk/item.def.
+ */
+
+import { attachGlobal } from "../utils/global.js";
+
+function round1(n) {
+  return Math.round(n * 10) / 10;
+}
+
+// Shared RNG helper (mirrors status_effects.js pattern)
+function getRng(ctx) {
+  try {
+    if (ctx && typeof ctx.rng === "function") return ctx.rng;
+  } catch (_) {}
+  try {
+    if (typeof window !== "undefined" && window.RNG && typeof window.RNG.rng === "function") {
+      if (typeof window.RNG.getSeed !== "function" || window.RNG.getSeed() == null) {
+        if (typeof window.RNG.autoInit === "function") window.RNG.autoInit();
+      }
+      return window.RNG.rng;
+    }
+  } catch (_) {}
+  return Math.random;
+}
+
+function randFloat(ctx, min, max, decimals = 1) {
+  const rng = getRng(ctx);
+  let r = 0.5;
+  try {
+    r = rng();
+  } catch (_) {
+    try { r = Math.random(); } catch (_) { r = 0.5; }
+  }
+  const v = min + r * (max - min);
+  const p = Math.pow(10, decimals);
+  return Math.round(v * p) / p;
+}
+
+function chance(ctx, p) {
+  const rng = getRng(ctx);
+  let r = 0.5;
+  try {
+    r = rng();
+  } catch (_) {
+    try { r = Math.random(); } catch (_) { r = 0.5; }
+  }
+  return r < p;
+}
+
+/**
+ * Increment Seen life usage counter on an item and, once eligible,
+ * apply a small permanent buff to atk/def.
+ *
+ * kind:
+ * - "weapon" → prefer atk
+ * - "armor"  → prefer def
+ * - anything else → fall back to atk, then def
+ */
+export function incrementSeenLifeUse(ctx, item, kind) {
+  if (!ctx || !item || item.kind !== "equip") return;
+
+  try {
+    const prev = (item._seenLifeUses | 0);
+    item._seenLifeUses = prev + 1;
+  } catch (_) {}
+
+  const uses = typeof item._seenLifeUses === "number" ? item._seenLifeUses : 0;
+  if (uses < 100) return;
+
+  // Ensure buffs container
+  let buffs = null;
+  try {
+    if (item.buffs && typeof item.buffs === "object") {
+      buffs = item.buffs;
+    } else {
+      buffs = {};
+      item.buffs = buffs;
+    }
+  } catch (_) {
+    // If we cannot attach a buffs object, still allow stat buff but skip metadata.
+  }
+
+  if (buffs && buffs.seenLife) return;
+
+  // One-time chance after the item has seen enough use
+  if (!chance(ctx, 0.3)) return; // ~30% once eligible
+
+  const amount = randFloat(ctx, 0.3, 0.5, 1);
+  let appliedKind = null;
+
+  if (kind === "weapon") {
+    if (typeof item.atk === "number") {
+      item.atk = round1(item.atk + amount);
+      appliedKind = "attack";
+    }
+  } else if (kind === "armor") {
+    if (typeof item.def === "number") {
+      item.def = round1(item.def + amount);
+      appliedKind = "defense";
+    }
+  }
+
+  // Fallback: prefer atk, then def
+  if (!appliedKind) {
+    if (typeof item.atk === "number") {
+      item.atk = round1(item.atk + amount);
+      appliedKind = "attack";
+    } else if (typeof item.def === "number") {
+      item.def = round1(item.def + amount);
+      appliedKind = "defense";
+    }
+  }
+
+  if (!appliedKind) return;
+
+  try {
+    if (buffs) {
+      buffs.seenLife = {
+        amount,
+        kind: appliedKind,
+      };
+    }
+  } catch (_) {}
+
+  // Log a small flavor line for the player
+  try {
+    if (ctx.log) {
+      const label = item.name || "item";
+      const statLabel = appliedKind === "attack" ? "attack" : "defense";
+      ctx.log(
+        `Seen life: ${label} is tempered by battle (+${amount.toFixed(1)} ${statLabel}).`,
+        "good",
+        { category: "Items" }
+      );
+    }
+  } catch (_) {}
+}
+
+/**
+ * Convenience helper for armor hits: increments Seen life usage for
+ * the equipped item in the given armor slot (head/torso/legs/hands).
+ */
+export function incrementSeenLifeUseForArmorSlot(ctx, slot) {
+  if (!ctx || !ctx.player || !ctx.player.equipment) return;
+  if (!slot) return;
+  try {
+    const eq = ctx.player.equipment;
+    const it = eq[slot];
+    if (!it || it.kind !== "equip") return;
+    incrementSeenLifeUse(ctx, it, "armor");
+  } catch (_) {}
+}
+
+// Back-compat / diagnostics: attach to window
+attachGlobal("ItemBuffs", {
+  incrementSeenLifeUse,
+  incrementSeenLifeUseForArmorSlot,
+});

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/inventory_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/inventory_panel.js
@@ -134,10 +134,17 @@ export function render(player, describeItem) {
     const html = slots.map(([key, label]) => {
       const it = player.equipment[key];
       if (it) {
-        const name = (typeof describeItem === "function") ? describeItem(it)
+        const baseName = (typeof describeItem === "function") ? describeItem(it)
           : ((typeof window !== "undefined" && window.ItemDescribe && typeof window.ItemDescribe.describe === "function")
               ? window.ItemDescribe.describe(it)
               : (it.name || "item"));
+        let name = baseName;
+        // Highlight Seen life buff in equipment slots.
+        try {
+          if (it.buffs && it.buffs.seenLife) {
+            name = `${baseName} <span class="seen-life-tag">(Seen life)</span>`;
+          }
+        } catch (_) {}
         const dec = Math.max(0, Math.min(100, Number(it.decay || 0)));
         const title = `Decay: ${dec.toFixed(0)}%`;
         return `<div class="slot"><strong>${label}:</strong> <span class="name" data-slot="${key}" title="${title}" style="cursor:pointer; text-decoration:underline dotted;">${name}</span></div>`;
@@ -204,6 +211,13 @@ export function render(player, describeItem) {
           label = `${baseLabel}${suffix}`;
         }
 
+        // Decorate Seen life buff in inventory list.
+        try {
+          if (it.buffs && it.buffs.seenLife) {
+            label = `${label} <span class="seen-life-tag">(Seen life)</span>`;
+          }
+        } catch (_) {}
+
         if (it.kind === "equip" && it.slot === "hand") {
           li.dataset.slot = "hand";
           const dec = Math.max(0, Math.min(100, Number(it.decay || 0)));
@@ -247,7 +261,7 @@ export function render(player, describeItem) {
           li.style.cursor = "default";
         }
 
-        li.textContent = label;
+        li.innerHTML = label;
         listEl.appendChild(li);
       });
       render._lastInvListKey = key;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/shop_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/shop_panel.js
@@ -123,11 +123,17 @@ function render(ctx) {
     } else {
       try {
         listDiv.innerHTML = '<div style="margin:4px 0 6px 0;color:#e2e8f0;">Items for sale</div>' + _stock.map(function (row, idx) {
-          const name = (ctx.describeItem
+          const baseName = (ctx.describeItem
             ? ctx.describeItem(row.item)
             : ((typeof window !== "undefined" && window.ItemDescribe && typeof window.ItemDescribe.describe === "function")
                 ? window.ItemDescribe.describe(row.item)
                 : (row.item && row.item.name) || "item"));
+          let name = baseName;
+          try {
+            if (row.item && row.item.buffs && row.item.buffs.seenLife) {
+              name = baseName + ' <span class="seen-life-tag">(Seen life)</span>';
+            }
+          } catch (_) {}
           const p = row.price | 0;
           const q = row.qty | 0;
           const disabled = q <= 0 ? 'disabled style="padding:4px 8px;background:#3b4557;color:#9aa3af;border:1px solid #4b5563;border-radius:4px;cursor:not-allowed;"' : 'style="padding:4px 8px;background:#243244;color:#e5e7eb;border:1px solid #334155;border-radius:4px;cursor:pointer;"';

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/utils/item_describe.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/utils/item_describe.js
@@ -10,7 +10,14 @@ export function describe(item) {
     const parts = [];
     if ("atk" in item) parts.push(`+${Number(item.atk).toFixed(1)} atk`);
     if ("def" in item) parts.push(`+${Number(item.def).toFixed(1)} def`);
-    return `${item.name}${parts.length ? " (" + parts.join(", ") + ")" : ""}`;
+    let name = item.name || "item";
+    // Append simple Seen life tag for text contexts (logs, plain UI).
+    try {
+      if (item.buffs && item.buffs.seenLife) {
+        name = `${name} (Seen life)`;
+      }
+    } catch (_) {}
+    return `${name}${parts.length ? " (" + parts.join(", ") + ")" : ""}`;
   }
   if (item.kind === "potion") {
     const heal = item.heal ?? 3;


### PR DESCRIPTION
Summary:
- Introduces a new item_buffs system to track and apply a permanent buff to weapons/armor after Seen Life usage.
- Automatically increments usage when gear is worn/used, and, after thresholds, grants a small permanent buff to atk/def on the item.
- Exposes utilities to increment usage for weapons and armor slots and integrates them across combat and town AI.
- Updates UI and item description to visibly indicate items that have Seen Life buffs.

What changed:
- New module: combat/item_buffs.js
  - Exports incrementSeenLifeUse(ctx, item, kind) and incrementSeenLifeUseForArmorSlot(ctx, slot).
  - Tracks per-item _seenLifeUses and, after ~100 uses and a 30% success chance, applies a small permanent buff to item.atk or item.def and marks buffs.seenLife with metadata.
  - Logs a flavor message when a buff is applied and attaches helpers to global ItemBuffs for compatibility.

- Combat integration
  - combat.js: imports incrementSeenLifeUse and, after a weapon attack, iterates equipped items (left, right, hands) and calls incrementSeenLifeUse(ctx, item, "weapon").
  - town_combat.js: imports incrementSeenLifeUseForArmorSlot and calls it when armor slots decay/are interacted with during town combat so armor gear can grant Seen Life buffs.
  - town ai / enemiesAct paths updated to track armor slot usage similarly.

- UI and descriptions
  - UI (inventory_panel.js, shop_panel.js): if an item has buffs.seenLife, appends a Seen life tag to the displayed name in equipment slots and shop listings.
  - UI details (inventory and shop) renderers updated to show the tag inline.
  - ui/utils/item_describe.js: describe(item) now appends "(Seen life)" to the item name for text contexts when buffs.seenLife exists.

Notes:
- The changes are designed to be non-breaking; use try/catch blocks where appropriate to avoid runtime errors if newer data isn’t present.
- The buff is permanent on the item and is tied to that specific piece of gear via item._seenLifeUses and buffs.seenLife metadata.
- The UI changes provide clear, consistent visibility of Seen Life buffs across equipment, inventories, and shops.

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/zps30cavfepp](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/zps30cavfepp)
Author: zakker111
