### PR TITLE
perf: add profiling hooks across town AI/render and tweak path budgeting and bed dedupe throttling

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
@@ -45,9 +45,9 @@
 - [FIXED] Seppo's True Blade (and other two-handed hand weapons that occupy both hands) previously counted Attack twice for followers when the same item was equipped in left and right; Attack/Defense aggregation for both players and followers now counts each equipped item only once so two-handed weapons behave as a single blade instead of double-stacking damage
 - In one dungeon run, Seppo spawned as a wild NPC inside a dungeon room but did not move or respond to interaction:
   - Seppo appeared in a dungeon context (not town), was stationary, and bumping into him did not open any dialog or shop UI.
-  - Needs investigation of how Seppo (or Seppo-like caravan blacksmith NPCs) can leak into dungeon spawns and why their interaction handler is not active there.
+  - Needs investigation of how Seppo (or Seppo-like caravan blacksmith NPCs) can leak into dungeon spawns
   - Likely related to shared prefab usage or NPC archetype reuse between town/castle and dungeon maps without proper mode-specific behavior.
 - World map sometimes shows leftover road tiles in unexpected places:
   - After some world generations, there are isolated or partial road segments that do not connect to towns, castles, or obvious points of interest.
   - These road remnants look like artifacts from previous road generation passes or abandoned routes and can appear in the middle of wilderness.
-  - Investigate overworld path/road generation and cleanup code to ensure roads are only kept when they connect meaningful locations and that unused draft paths are removed.
+  - Investigate overworld path/road generation and cleanup code to ensure roads are only kept when they connect meaningful locations and that unused draft paths are removed. Or remove them completely

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
@@ -43,3 +43,11 @@
   - In some runs, followers later appear only in scripted encounters (e.g., overworld events) and can spawn far away from the player instead of near the player’s position.
   - Likely related to FollowersRuntime.spawnInDungeon/spawnInTown and syncFollowersFromTown/syncFollowersFromDungeon not fully updating follower runtime state across town sleep/rest flows; needs a focused repro path and inspection of follower record vs runtime actors when using inns.
 - [FIXED] Seppo's True Blade (and other two-handed hand weapons that occupy both hands) previously counted Attack twice for followers when the same item was equipped in left and right; Attack/Defense aggregation for both players and followers now counts each equipped item only once so two-handed weapons behave as a single blade instead of double-stacking damage
+- In one dungeon run, Seppo spawned as a wild NPC inside a dungeon room but did not move or respond to interaction:
+  - Seppo appeared in a dungeon context (not town), was stationary, and bumping into him did not open any dialog or shop UI.
+  - Needs investigation of how Seppo (or Seppo-like caravan blacksmith NPCs) can leak into dungeon spawns and why their interaction handler is not active there.
+  - Likely related to shared prefab usage or NPC archetype reuse between town/castle and dungeon maps without proper mode-specific behavior.
+- World map sometimes shows leftover road tiles in unexpected places:
+  - After some world generations, there are isolated or partial road segments that do not connect to towns, castles, or obvious points of interest.
+  - These road remnants look like artifacts from previous road generation passes or abandoned routes and can appear in the middle of wilderness.
+  - Investigate overworld path/road generation and cleanup code to ensure roads are only kept when they connect meaningful locations and that unused draft paths are removed.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
@@ -450,7 +450,7 @@ These are primarily for debugging and development, not normal gameplay.
 - Logging / fallback logging:
   - Centralized fallback logger for robust behavior when primary facilities are missing.
 - Health checks and data validation:
-  - Boot-time HealthCheck runs a lightweight module/data health pass after `GameData.ready` and logs a summary (`Health: X errors, Y warnings.`) plus one line per module/domain.
+  - Boot-time HealthCheck runs a lightweight module/data health pass after `GameData.ready` and logs a summary (`Health: X errors, Y warnings.`) plus one line per module/domain, without running the full schema validator on every startup.
   - The GOD panel’s **Run Validation** button triggers full data validation and now prints detailed warnings/notices (per category and per message) into both the main log and the Town Debug output box so data issues (items, enemies, shops, palette, encounters, etc.) are visible without opening the browser console.
 - Smoke tests:
   - Automated smoketest runner to exercise core flows (entry/exit, movement, basic combat, etc.).

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
@@ -449,6 +449,9 @@ These are primarily for debugging and development, not normal gameplay.
 
 - Logging / fallback logging:
   - Centralized fallback logger for robust behavior when primary facilities are missing.
+- Health checks and data validation:
+  - Boot-time HealthCheck runs a lightweight module/data health pass after `GameData.ready` and logs a summary (`Health: X errors, Y warnings.`) plus one line per module/domain.
+  - The GOD panel’s **Run Validation** button triggers full data validation and now prints detailed warnings/notices (per category and per message) into both the main log and the Town Debug output box so data issues (items, enemies, shops, palette, encounters, etc.) are visible without opening the browser console.
 - Smoke tests:
   - Automated smoketest runner to exercise core flows (entry/exit, movement, basic combat, etc.).
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -51,6 +51,10 @@ This file collects planned features, ideas, and technical cleanups that were pre
   - Allow NPCs (town, dungeon, region, followers) to move diagonally when appropriate, not just in 4 cardinal directions.
   - Update pathfinding heuristics and collision checks so diagonal steps respect walls, doors, props, and other blockers (no corner cutting through wall corners).
   - Ensure diagonal-capable pathfinding is shared between TownAI, dungeon AI, and follower movement so behavior stays consistent.
+- [ ] Town AI priority: always prioritize shopkeepers reaching their shops
+  - In town performance throttling (NPC budgets, distance bands), ensure shopkeepers who are currently off-duty but need to reach their shop (opening, closing, or on-duty window) are always given high priority, even when they are far away from the player.
+  - Adjust TownAI scheduling so shopkeepers do not “freeze” just because they are in a far band; their movement toward their shop should be considered critical for town believability.
+  - Keep guards and critical events (e.g., bandits at gate) as high priority, but make shopkeepers’ commute to their shop part of the “must-run” set each tick.
 - [ ] Player skill tree and skill points
   - Perception skill that affects how far the player sees other creatures/enemies, and how early encounters/animals are sensed.
   - “Campman” / survival skill affecting animal sensing and how often the player can safely flee from encounters.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -272,6 +272,27 @@ This file collects planned features, ideas, and technical cleanups that were pre
 
 ## Technical / Cleanup
 
+- [ ] Startup diagnostics & loading visualization
+  - Add a small startup overlay or HUD element that shows which subsystems have finished initializing:
+    - JSON registries via `GameData.ready` (items, enemies, npcs, consumables, encounters, shop pools, tiles/props, etc.).
+    - Core engine modules (WorldRuntime, DungeonRuntime, RNG service, GameLoop, Render, UIOrchestration, ShopService, etc.).
+    - HealthCheck status (module/data health summary).
+  - Design goals:
+    - Visible but unobtrusive: a compact panel or progress bar that appears in the corner during boot, then auto-hides once everything is ready.
+    - Data-driven: use a simple event or hook API so modules and data loaders can report “started/finished/failed” without hard-coding each step in the UI.
+    - Useful for debugging: make it easy to see when a domain is slow or failing (e.g., missing encounters.json or shop_pools.json) without opening the browser console.
+  - Implementation sketch:
+    - Introduce a small `BootMonitor`/`StartupStatus` module that:
+      - Tracks named steps like `GameData.items`, `GameData.encounters`, `WorldRuntime.generate`, `HealthCheck.run`.
+      - Exposes a minimal API (`markStarted(name)`, `markDone(name)`, `markFailed(name, error)`) and a `getSnapshot()` for UI.
+    - Wire `BootMonitor` into:
+      - `data/loader.js` around key `fetchJson` calls (especially consumables, encounters, shop pools).
+      - `core/engine/game_orchestrator.js` during world/town/dungeon initialization.
+      - `core/engine/health_check.js` when running module/data health checks.
+    - Add a tiny UI component to `ui/ui.js` / `GodPanel` that:
+      - Shows an overall progress bar (percentage of tracked steps complete) and a collapsible list of step names with status (OK / pending / failed).
+      - Allows forcing a re-run of HealthCheck and/or data validation from the GOD panel to refresh the view.
+
 - [ ] Mountain-pass dungeons: design and implement a complete rework of A/B linked mountain-pass dungeon behavior (portal logic, overworld exit targets, and persistence); current implementation is experimental and unreliable.
 - [ ] GOD panel: add a toggle to visualize enemy FOV/vision cones
   - GOD toggle that overlays the current FOV/vision radius of selected enemies (or all enemies) on the map:

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -277,24 +277,27 @@ This file collects planned features, ideas, and technical cleanups that were pre
 ## Technical / Cleanup
 
 - [ ] Startup diagnostics & loading visualization
-  - Add a small startup overlay or HUD element that shows which subsystems have finished initializing:
+  - Keep startup fast by treating “game becomes playable quickly” as the primary goal and running heavy validations only on demand:
+    - Boot-time HealthCheck should remain a lightweight presence/shape pass over modules and data, deferring full schema validation to GOD/dev tools.
+    - Any future startup HUD must not block world generation or main loop start while waiting on deep validators.
+  - Add an optional, dev-focused startup overlay or GOD panel section that shows which subsystems have finished initializing:
     - JSON registries via `GameData.ready` (items, enemies, npcs, consumables, encounters, shop pools, tiles/props, etc.).
     - Core engine modules (WorldRuntime, DungeonRuntime, RNG service, GameLoop, Render, UIOrchestration, ShopService, etc.).
     - HealthCheck status (module/data health summary).
   - Design goals:
-    - Visible but unobtrusive: a compact panel or progress bar that appears in the corner during boot, then auto-hides once everything is ready.
+    - Visible but unobtrusive: a compact panel in GOD or a dev-only overlay that appears during boot and can be disabled in normal play.
     - Data-driven: use a simple event or hook API so modules and data loaders can report “started/finished/failed” without hard-coding each step in the UI.
     - Useful for debugging: make it easy to see when a domain is slow or failing (e.g., missing encounters.json or shop_pools.json) without opening the browser console.
   - Implementation sketch:
-    - Introduce a small `BootMonitor`/`StartupStatus` module that:
+    - Keep a small `BootMonitor`/`StartupStatus` module that:
       - Tracks named steps like `GameData.items`, `GameData.encounters`, `WorldRuntime.generate`, `HealthCheck.run`.
       - Exposes a minimal API (`markStarted(name)`, `markDone(name)`, `markFailed(name, error)`) and a `getSnapshot()` for UI.
     - Wire `BootMonitor` into:
       - `data/loader.js` around key `fetchJson` calls (especially consumables, encounters, shop pools).
       - `core/engine/game_orchestrator.js` during world/town/dungeon initialization.
       - `core/engine/health_check.js` when running module/data health checks.
-    - Add a tiny UI component to `ui/ui.js` / `GodPanel` that:
-      - Shows an overall progress bar (percentage of tracked steps complete) and a collapsible list of step names with status (OK / pending / failed).
+    - Add a small UI surface (likely in GOD) that:
+      - Shows an overall progress indicator (percentage of tracked steps complete) and a list of step names with status (OK / pending / failed).
       - Allows forcing a re-run of HealthCheck and/or data validation from the GOD panel to refresh the view.
 
 - [ ] Mountain-pass dungeons: design and implement a complete rework of A/B linked mountain-pass dungeon behavior (portal logic, overworld exit targets, and persistence); current implementation is experimental and unreliable.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -311,3 +311,7 @@ This file collects planned features, ideas, and technical cleanups that were pre
 - [ ] Smoketest runner:
   - Remove positional “nudge” for dungeon entry, town entry, dungeon exit, and town exit.
   - Make smoketest positions exact in tiles; only use nudge around NPC interaction or enemy interaction.
+- [ ] Dungeon NPC spawn hygiene:
+  - Ensure town-only NPC archetypes (e.g., Seppo and caravan blacksmiths) cannot spawn as “wild” NPCs in dungeon contexts unless explicitly intended, and that any such NPCs have correct movement and interaction handlers when they do appear.
+- [ ] Overworld road cleanup:
+  - Review overworld road/path generation and pruning so that roads only remain when they connect meaningful POIs (towns, castles, dungeons, ruins) and stray/isolated road segments in wilderness are removed as part of a final cleanup pass.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
@@ -25,6 +25,12 @@ v1.68.0 — HealthCheck tuning, validation details, and bug tracking updates
     - The GOD log still shows `Health: 0 errors, N warnings.` at startup.
     - The two remaining warnings are for optional/experimental modules (HarborGeneration, Fallbacks) and are considered acceptable in this build.
 
+- NPC performance focus:
+  - Town AI and NPC scheduling remain a major performance focus for upcoming work:
+    - TODO.md now tracks that shopkeepers should be prioritized to reach their shops (open/close/on-duty windows) even when they are far from the player and subject to distance-based throttling.
+    - Future iterations will keep per-turn NPC budgets, distance bands, and throttling in place for performance, but treat shopkeepers (and critical roles like guards or event NPCs) as “must-run” updates so towns feel alive without sacrificing frame time.
+  - These changes are currently design/plan-level and will be implemented in a future version; they are documented here to make the performance intent for NPC behavior explicit alongside the HealthCheck/validation improvements.
+
 - Data and AI adjustments:
   - data/entities/enemies.json:
     - `guard_elite` enemy tier has been normalized from 4 to 3 so it fits the 1..3 tier system used by items and encounter scaling, while keeping its HP/ATK/XP curves strong enough to be clearly above regular guards.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
@@ -15,9 +15,11 @@ v1.68.0 — HealthCheck tuning, validation details, and bug tracking updates
       - Emits each individual warning/notice line to the main Logger (up to a safety cap) so the GOD panel log shows exactly which items/enemies/shops need attention.
     - The Town Debug output box (`god-check-output`) is now populated with a summary plus a “Details (warnings/notices)” section listing concrete messages, making it easier to see exactly what the validator is complaining about without opening the browser console.
 
-- Startup diagnostics / HUD:
-  - A lightweight BootMonitor module was introduced earlier to track data/health status and drive an on-screen boot HUD, but the HUD overlay itself has been removed for normal play:
-    - BootMonitor remains available for internal tracking and potential future dev tools.
+- Startup performance and diagnostics:
+  - Startup now keeps long-running validation off the boot path:
+    - Full schema validation (items/enemies/shops/encounters/etc.) only runs when explicitly requested from the GOD panel or dev flows; the automatic HealthCheck at boot only does quick presence/shape checks.
+    - This reduces boot-time CPU spikes and makes “game shows and responds quickly” the priority, while keeping deep validation available when needed.
+  - A lightweight BootMonitor module was introduced earlier to track data/health status and can still be used by dev tooling, but the on-screen boot HUD overlay has been removed for normal play:
     - There is no longer a persistent bottom-left health/status box; health results are visible via the GOD log instead.
   - Health summary at boot remains:
     - The GOD log still shows `Health: 0 errors, N warnings.` at startup.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/town_movement.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/town_movement.js
@@ -17,7 +17,22 @@ const PATH_BUDGET_MAX = 32;
 
 function initPathBudget(ctx, npcCount) {
   const phaseNow = (ctx && ctx.time && ctx.time.phase) ? String(ctx.time.phase) : "day";
-  const baseFrac = (phaseNow === "day") ? 0.26 : 0.18;
+  const size = (ctx && typeof ctx.townSize === "string") ? ctx.townSize : "big";
+
+  // Base fraction scales with town size and is slightly adjusted by time of day.
+  let baseFrac;
+  if (size === "small") baseFrac = 0.20;
+  else if (size === "city") baseFrac = 0.30;
+  else baseFrac = 0.26;
+
+  if (phaseNow === "night") {
+    baseFrac *= 0.8;
+  } else if (phaseNow === "dusk") {
+    baseFrac *= 1.1;
+  } else if (phaseNow === "dawn") {
+    baseFrac *= 0.9;
+  }
+
   const approx = Math.max(1, Math.floor(npcCount * baseFrac));
   const defaultBudget = Math.max(
     PATH_BUDGET_MIN,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/town_runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/town_runtime.js
@@ -70,7 +70,17 @@ function townNPCsAct(ctx) {
     try { ctx.log && ctx.log("The guards drive off the bandits at the gate.", "good"); } catch (_) {}
   }
 
-  dedupeHomeBeds(ctx);
+  // Dedupe home beds periodically instead of every tick to reduce hot-path work.
+  try {
+    const time = ctx.time;
+    const turn = time && typeof time.turnCounter === "number" ? (time.turnCounter | 0) : 0;
+    if (!ctx._dedupeBedsLastRun || (turn - ctx._dedupeBedsLastRun) >= 20) {
+      dedupeHomeBeds(ctx);
+      ctx._dedupeBedsLastRun = turn;
+    }
+  } catch (_) {
+    dedupeHomeBeds(ctx);
+  }
 
   const occ = new Set();
   occ.add(`${player.x},${player.y}`);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/boot_monitor.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/boot_monitor.js
@@ -1,0 +1,89 @@
+/**
+ * BootMonitor: lightweight global tracker for startup data/health status.
+ *
+ * Exposed via window.BootMonitor and ES module exports:
+ *  - markData(status, info?)
+ *  - markHealthSummary(result)
+ *  - markValidation(status, summary?)
+ *  - snapshot()
+ */
+
+import { attachGlobal } from "../../utils/global.js";
+
+const state = {
+  data: {
+    status: "pending", // "pending" | "ok" | "warn" | "error"
+    finishedAt: 0,
+    info: null,
+  },
+  health: {
+    status: "pending", // "pending" | "ok" | "warn" | "error"
+    errors: 0,
+    warns: 0,
+    finishedAt: 0,
+  },
+  validation: {
+    status: "idle", // "idle" | "running" | "done" | "error"
+    summary: null,
+    finishedAt: 0,
+  },
+};
+
+function markData(status, info) {
+  try {
+    const now = Date.now();
+    const s = status || "ok";
+    state.data.status = s;
+    state.data.finishedAt = now;
+    if (info && typeof info === "object") {
+      state.data.info = Object.assign({}, info);
+    }
+  } catch (_) {}
+}
+
+function markHealthSummary(result) {
+  try {
+    const now = Date.now();
+    const errors = result && typeof result.errors === "number" ? (result.errors | 0) : 0;
+    const warns = result && typeof result.warns === "number" ? (result.warns | 0) : 0;
+    let status = "ok";
+    if (errors > 0) status = "error";
+    else if (warns > 0) status = "warn";
+
+    state.health.status = status;
+    state.health.errors = errors;
+    state.health.warns = warns;
+    state.health.finishedAt = now;
+  } catch (_) {}
+}
+
+function markValidation(status, summary) {
+  try {
+    const now = Date.now();
+    state.validation.status = status || "done";
+    if (summary && typeof summary === "object") {
+      state.validation.summary = Object.assign({}, summary);
+    }
+    state.validation.finishedAt = now;
+  } catch (_) {}
+}
+
+function snapshot() {
+  try {
+    return {
+      data: Object.assign({}, state.data),
+      health: Object.assign({}, state.health),
+      validation: Object.assign({}, state.validation),
+    };
+  } catch (_) {
+    return {
+      data: { status: "pending", finishedAt: 0, info: null },
+      health: { status: "pending", errors: 0, warns: 0, finishedAt: 0 },
+      validation: { status: "idle", summary: null, finishedAt: 0 },
+    };
+  }
+}
+
+attachGlobal("BootMonitor", { markData, markHealthSummary, markValidation, snapshot });
+
+export { markData, markHealthSummary, markValidation, snapshot };

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/flows.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/flows.js
@@ -1,0 +1,174 @@
+/**
+ * Town flow fields: precomputed distance maps used by TownAI for common targets
+ * such as the plaza, town gate, and inn door.
+ *
+ * API (ESM + window.TownFlows):
+ *  - computeFlowField(ctx, targets)
+ *  - computeTownFlowFields(ctx)
+ */
+
+function isWalkTownBasic(ctx, x, y) {
+  const map = Array.isArray(ctx.map) ? ctx.map : null;
+  const T = ctx && ctx.TILES;
+  if (!map || !map.length || !T) return false;
+  const rows = map.length;
+  const cols = map[0] ? map[0].length : 0;
+  if (x < 0 || y < 0 || x >= cols || y >= rows) return false;
+  const t = map[y][x];
+  return t === T.FLOOR || t === T.DOOR || t === T.ROAD;
+}
+
+/**
+ * Compute a flow field (distance map) from one or more target tiles.
+ * Returns a HxW array of Int16Array rows, with -1 indicating unreachable.
+ */
+export function computeFlowField(ctx, targets) {
+  try {
+    const map = Array.isArray(ctx.map) ? ctx.map : null;
+    if (!map || !map.length || !Array.isArray(targets) || !targets.length) return null;
+    const H = map.length;
+    const W = map[0] ? map[0].length : 0;
+    if (!W) return null;
+
+    const dist = Array.from({ length: H }, () => {
+      const row = new Int16Array(W);
+      row.fill(-1);
+      return row;
+    });
+
+    const q = [];
+    for (const t of targets) {
+      if (!t) continue;
+      const x = t.x | 0;
+      const y = t.y | 0;
+      if (x < 0 || y < 0 || x >= W || y >= H) continue;
+      if (!isWalkTownBasic(ctx, x, y)) continue;
+      if (dist[y][x] !== -1) continue;
+      dist[y][x] = 0;
+      q.push(x, y);
+    }
+    if (!q.length) return null;
+
+    const dirs = [
+      { dx: 1, dy: 0 },
+      { dx: -1, dy: 0 },
+      { dx: 0, dy: 1 },
+      { dx: 0, dy: -1 }
+    ];
+
+    let qi = 0;
+    while (qi < q.length) {
+      const x = q[qi++] | 0;
+      const y = q[qi++] | 0;
+      const d = dist[y][x];
+      if (d >= 0x7fff) continue;
+      const nd = d + 1;
+      for (let i = 0; i < dirs.length; i++) {
+        const nx = x + dirs[i].dx;
+        const ny = y + dirs[i].dy;
+        if (nx < 0 || ny < 0 || nx >= W || ny >= H) continue;
+        if (dist[ny][nx] !== -1) continue;
+        if (!isWalkTownBasic(ctx, nx, ny)) continue;
+        dist[ny][nx] = nd;
+        q.push(nx, ny);
+      }
+    }
+
+    return dist;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Compute and attach common town flow fields to ctx:
+ *  - ctx.flowToPlaza
+ *  - ctx.flowToGate
+ *  - ctx.flowToInnDoor
+ *  - ctx.flowToHarborBand (only when harbor mask exists)
+ */
+export function computeTownFlowFields(ctx) {
+  try {
+    if (!ctx || !Array.isArray(ctx.map) || !ctx.map.length) return;
+
+    try {
+      ctx.flowToPlaza = null;
+      ctx.flowToGate = null;
+      ctx.flowToInnDoor = null;
+      ctx.flowToHarborBand = null;
+    } catch (_) {}
+
+    const map = ctx.map;
+    const H = map.length;
+    const W = map[0] ? map[0].length : 0;
+    if (!W) return;
+
+    // Plaza
+    try {
+      const pl = ctx.townPlaza;
+      if (pl && typeof pl.x === "number" && typeof pl.y === "number") {
+        const field = computeFlowField(ctx, [pl]);
+        if (field) ctx.flowToPlaza = field;
+      }
+    } catch (_) {}
+
+    // Gate
+    try {
+      const gate = ctx.townExitAt;
+      if (gate && typeof gate.x === "number" && typeof gate.y === "number") {
+        const field = computeFlowField(ctx, [gate]);
+        if (field) ctx.flowToGate = field;
+      }
+    } catch (_) {}
+
+    // Inn door(s)
+    try {
+      const innTargets = [];
+      const shops = Array.isArray(ctx.shops) ? ctx.shops : [];
+      for (let i = 0; i < shops.length; i++) {
+        const s = shops[i];
+        if (!s) continue;
+        const t = String(s.type || "").toLowerCase();
+        if (t !== "inn") continue;
+        if (!s.x && s.x !== 0) continue;
+        if (!s.y && s.y !== 0) continue;
+        innTargets.push({ x: s.x | 0, y: s.y | 0 });
+      }
+      if (!innTargets.length && ctx.tavern && ctx.tavern.door && typeof ctx.tavern.door.x === "number" && typeof ctx.tavern.door.y === "number") {
+        innTargets.push({ x: ctx.tavern.door.x | 0, y: ctx.tavern.door.y | 0 });
+      }
+      if (innTargets.length) {
+        const field = computeFlowField(ctx, innTargets);
+        if (field) ctx.flowToInnDoor = field;
+      }
+    } catch (_) {}
+
+    // Harbor band (only if harbor mask present; primarily for fresh port towns)
+    try {
+      const mask = Array.isArray(ctx.townHarborMask) ? ctx.townHarborMask : null;
+      if (mask && ctx.townKind === "port") {
+        const targets = [];
+        const rows = mask.length;
+        const cols = mask[0] ? mask[0].length : 0;
+        for (let y = 0; y < rows; y++) {
+          const row = mask[y];
+          if (!Array.isArray(row)) continue;
+          for (let x = 0; x < cols; x++) {
+            if (row[x]) targets.push({ x, y });
+          }
+        }
+        if (targets.length) {
+          const field = computeFlowField(ctx, targets);
+          if (field) ctx.flowToHarborBand = field;
+        }
+      }
+    } catch (_) {}
+  } catch (_) {}
+}
+
+// Back-compat/debug: attach to window
+if (typeof window !== "undefined") {
+  try {
+    window.TownFlows = { computeFlowField, computeTownFlowFields };
+  } catch (_) {}
+}

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/runtime.js
@@ -491,7 +491,20 @@ export function tick(ctx) {
   try {
     const TAI = ctx.TownAI || (typeof window !== "undefined" ? window.TownAI : null);
     if (TAI && typeof TAI.townNPCsAct === "function") {
+      let t0 = null;
+      try {
+        if (typeof performance !== "undefined" && performance && typeof performance.now === "function") {
+          t0 = performance.now();
+        }
+      } catch (_) {}
       TAI.townNPCsAct(ctx);
+      if (t0 != null) {
+        try {
+          const dt = performance.now() - t0;
+          ctx._perfTownAIAccum = (ctx._perfTownAIAccum || 0) + dt;
+          ctx._perfTownAICount = (ctx._perfTownAICount || 0) + 1;
+        } catch (_) {}
+      }
     }
   } catch (_) {}
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/state.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/state.js
@@ -13,6 +13,7 @@
  */
 
 import { getMod } from "../../utils/access.js";
+import { computeTownFlowFields } from "./flows.js";
 
 const LS_KEY = "TOWN_STATES_V1";
 
@@ -427,6 +428,9 @@ function applyState(ctx, st, x, y) {
     } catch (_) {}
     try { ctx._townBiomeResolved = true; } catch (_) {}
   } catch (_) {}
+
+  // Recompute flow fields (plaza, gate, inn door, harbor band) after restoring map/shops/props.
+  try { computeTownFlowFields(ctx); } catch (_) {}
 
   // Place player at the town gate (exit tile) if available
   try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/validation_runner.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/validation_runner.js
@@ -250,8 +250,8 @@ export function run(ctx = null) {
           try { const list = GD.materials && (Array.isArray(GD.materials.materials) ? GD.materials.materials : GD.materials.list); if (!Array.isArray(list)) return false; const t = String(idOrType || ""); return !!list.find(m => String(m.id || "").toLowerCase() === t.toLowerCase() || String(m.name || "").toLowerCase() === t.toLowerCase()); } catch (_) { return false; }
         }
 
-        const KIND_OK = new Set(["potion","antidote","weapon","low_tier_equip","shield","armor","tool","material","curio","food","drink"]);
-        const EQUIP_KINDS = new Set(["weapon","low_tier_equip","shield","armor"]);
+        const KIND_OK = new Set(["potion","antidote","weapon","low_tier_equip","shield","armor","tool","material","curio","food","drink","named_equip"]);
+        const EQUIP_KINDS = new Set(["weapon","low_tier_equip","shield","armor","named_equip"]);
 
         if (poolsRoot && typeof poolsRoot === "object") {
           for (const shopType of Object.keys(poolsRoot)) {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/entities/enemies.json
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/entities/enemies.json
@@ -129,7 +129,7 @@
       "potions": { "lesser": 0.50, "average": 0.35, "strong": 0.15 }
     }
   },
-  { "id": "guard_elite", "glyph": "G", "color": "#1d4ed8", "tier": 4, "blockBase": 0.15, "faction": "guard",
+  { "id": "guard_elite", "glyph": "G", "color": "#1d4ed8", "tier": 3, "blockBase": 0.15, "faction": "guard",
     "weightByDepth": [ [999, 0.08] ],
     "hp": [ [0, 11, 1.4], [5, 15, 1.6] ],
     "atk": [ [0, 4, 0.7], [5, 5, 0.8] ],

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
@@ -462,6 +462,24 @@ GameData.ready = (async function loadAll() {
     if (!GameData.items || !GameData.enemies || !GameData.npcs || !GameData.consumables || !GameData.town || !GameData.flavor || !GameData.tiles || !GameData.encounters) {
       logNotice("Some registries failed to load; modules will use internal fallbacks.");
     }
+
+    // Notify BootMonitor (if present) that data loading has finished.
+    try {
+      const BM = (typeof window !== "undefined") ? window.BootMonitor : null;
+      if (BM && typeof BM.markData === "function") {
+        const ok = !!(GameData.items && GameData.enemies && GameData.npcs && GameData.consumables && GameData.town && GameData.flavor && GameData.tiles && GameData.encounters);
+        BM.markData(ok ? "ok" : "warn", {
+          items: !!GameData.items,
+          enemies: !!GameData.enemies,
+          npcs: !!GameData.npcs,
+          consumables: !!GameData.consumables,
+          town: !!GameData.town,
+          flavor: !!GameData.flavor,
+          tiles: !!GameData.tiles,
+          encounters: !!GameData.encounters,
+        });
+      }
+    } catch (_) {}
   } catch (e) {
     try { console.warn("[GameData] load error", e); } catch (_) {}
     // Keep whatever loaded; modules across the codebase provide sensible fallbacks.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
@@ -84,13 +84,14 @@ function fetchJson(url) {
   const url2 = withVer(url);
 
   // Guard against pathological network stalls by applying a per-request timeout.
-  // If the timeout elapses, we abort the fetch and allow callers to fall back.
+  // Use a generous timeout so slow connections still load full data; this mainly
+  // protects against truly hung requests.
   let controller = null;
   let timeoutId = null;
   try {
     if (typeof AbortController !== "undefined") {
       controller = new AbortController();
-      const TIMEOUT_MS = 8000;
+      const TIMEOUT_MS = 30000; // 30s to avoid false timeouts on slow networks
       timeoutId = setTimeout(() => {
         try { controller.abort(); } catch (_) {}
       }, TIMEOUT_MS);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
@@ -95,7 +95,6 @@
       } catch (_) {}
     })();
   </script>
-  <div id="boot-status" class="boot-status" hidden></div>
 
   <div id="loot-panel" class="loot-panel" hidden>
     <div class="loot-title">Loot acquired</div>
@@ -338,54 +337,6 @@
           else if (m === "0") window.LOG_MIRROR = false;
           // default: enabled unless user turned it off
         }
-      } catch (_) {}
-    })();
-  </script>
-
-  <!-- Startup / health status overlay driven by BootMonitor -->
-  <script>
-    (function () {
-      function updateBootStatus() {
-        try {
-          var el = document.getElementById("boot-status");
-          if (!el) return;
-          var BM = (typeof window !== "undefined") ? window.BootMonitor : null;
-          if (!BM || typeof BM.snapshot !== "function") {
-            el.hidden = true;
-            return;
-          }
-          var snap = BM.snapshot();
-          var parts = [];
-          var cls = "good";
-
-          if (snap.data && snap.data.status && snap.data.status !== "pending") {
-            parts.push("Data: " + snap.data.status);
-            if (snap.data.status === "warn") cls = "warn";
-            else if (snap.data.status === "error") cls = "bad";
-          } else {
-            parts.push("Data: loading...");
-            cls = "warn";
-          }
-
-          if (snap.health && snap.health.status && snap.health.status !== "pending") {
-            parts.push("Health: " + snap.health.errors + " errors, " + snap.health.warns + " warnings");
-            if (snap.health.status === "warn" && cls === "good") cls = "warn";
-            if (snap.health.status === "error") cls = "bad";
-          } else {
-            parts.push("Health: pending");
-          }
-
-          if (!parts.length) {
-            el.hidden = true;
-            return;
-          }
-          el.textContent = parts.join(" | ");
-          el.hidden = false;
-          el.className = "boot-status " + cls;
-        } catch (_) {}
-      }
-      try {
-        setInterval(updateBootStatus, 1000);
       } catch (_) {}
     })();
   </script>

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
@@ -16,7 +16,7 @@
     connect-src 'self';
   ">
   <!-- App version for storage invalidation on deploy -->
-  <meta name="app-version" content="1.49.4">
+  <meta name="app-version" content="1.50.0">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/ui/style.css">

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
@@ -95,6 +95,7 @@
       } catch (_) {}
     })();
   </script>
+  <div id="boot-status" class="boot-status" hidden></div>
 
   <div id="loot-panel" class="loot-panel" hidden>
     <div class="loot-title">Loot acquired</div>
@@ -337,6 +338,54 @@
           else if (m === "0") window.LOG_MIRROR = false;
           // default: enabled unless user turned it off
         }
+      } catch (_) {}
+    })();
+  </script>
+
+  <!-- Startup / health status overlay driven by BootMonitor -->
+  <script>
+    (function () {
+      function updateBootStatus() {
+        try {
+          var el = document.getElementById("boot-status");
+          if (!el) return;
+          var BM = (typeof window !== "undefined") ? window.BootMonitor : null;
+          if (!BM || typeof BM.snapshot !== "function") {
+            el.hidden = true;
+            return;
+          }
+          var snap = BM.snapshot();
+          var parts = [];
+          var cls = "good";
+
+          if (snap.data && snap.data.status && snap.data.status !== "pending") {
+            parts.push("Data: " + snap.data.status);
+            if (snap.data.status === "warn") cls = "warn";
+            else if (snap.data.status === "error") cls = "bad";
+          } else {
+            parts.push("Data: loading...");
+            cls = "warn";
+          }
+
+          if (snap.health && snap.health.status && snap.health.status !== "pending") {
+            parts.push("Health: " + snap.health.errors + " errors, " + snap.health.warns + " warnings");
+            if (snap.health.status === "warn" && cls === "good") cls = "warn";
+            if (snap.health.status === "error") cls = "bad";
+          } else {
+            parts.push("Health: pending");
+          }
+
+          if (!parts.length) {
+            el.hidden = true;
+            return;
+          }
+          el.textContent = parts.join(" | ");
+          el.hidden = false;
+          el.className = "boot-status " + cls;
+        } catch (_) {}
+      }
+      try {
+        setInterval(updateBootStatus, 1000);
       } catch (_) {}
     })();
   </script>

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/src/main.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/src/main.js
@@ -6,6 +6,7 @@
 import '/core/ctx.js';
 import '/core/rng_service.js';
 import '/core/state/state_sync.js';
+import '/core/engine/boot_monitor.js';
 
 // Utilities
 import '/utils/utils.js';

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render/lamp_glow.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render/lamp_glow.js
@@ -42,8 +42,8 @@ export function drawLampGlow(ctx, view) {
     const mapRows = ctx.map.length;
     const mapCols = ctx.map[0] ? ctx.map[0].length : 0;
     const wpx = mapCols * TILE, hpx = mapRows * TILE;
-    const turn = (ctx.time && typeof ctx.time.turnCounter === "number") ? (ctx.time.turnCounter | 0) : 0;
     const phase = ctx.time && ctx.time.phase ? String(ctx.time.phase) : "";
+    const glowVersion = (typeof ctx._lampGlowVersion === "number") ? ctx._lampGlowVersion : 0;
 
     let layer = ctx._lampGlowLayer || null;
     const needsRebuild =
@@ -53,8 +53,8 @@ export function drawLampGlow(ctx, view) {
       layer.wpx !== wpx ||
       layer.hpx !== hpx ||
       layer.phase !== phase ||
-      layer.turn !== turn ||
-      layer.count !== lights.length;
+      layer.count !== lights.length ||
+      layer.version !== glowVersion;
 
     if (needsRebuild) {
       const off = document.createElement("canvas");
@@ -102,8 +102,8 @@ export function drawLampGlow(ctx, view) {
         wpx,
         hpx,
         phase,
-        turn,
-        count: lights.length
+        count: lights.length,
+        version: glowVersion
       };
       ctx._lampGlowLayer = layer;
     }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render_town.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render_town.js
@@ -41,6 +41,13 @@ export function draw(ctx, view) {
     cam, tileOffsetX, tileOffsetY, startX, startY, endX, endY
   } = Object.assign({}, view, ctx);
 
+  let _townDrawPerfStart = null;
+  try {
+    if (typeof performance !== "undefined" && performance && typeof performance.now === "function") {
+      _townDrawPerfStart = performance.now();
+    }
+  } catch (_) {}
+
   
   const mapRows = map.length;
   const mapCols = map[0] ? map[0].length : 0;
@@ -216,6 +223,14 @@ export function draw(ctx, view) {
 
   // Grid overlay (if enabled)
   RenderCore.drawGridOverlay(view);
+
+  if (_townDrawPerfStart != null) {
+    try {
+      const dt = performance.now() - _townDrawPerfStart;
+      ctx._perfTownDrawAccum = (ctx._perfTownDrawAccum || 0) + dt;
+      ctx._perfTownDrawCount = (ctx._perfTownDrawCount || 0) + 1;
+    } catch (_) {}
+  }
 }
 
 // Back-compat: attach to window via helper

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/style.css
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/style.css
@@ -337,3 +337,25 @@ html, body {
   gap: 8px;
   align-items: center;
 }
+
+/* Boot / startup status indicator */
+.boot-status {
+  position: fixed;
+  bottom: 12px;
+  left: 12px;
+  padding: 6px 10px;
+  background: rgba(15, 23, 42, 0.94);
+  border-radius: 8px;
+  border: 1px solid rgba(122, 162, 247, 0.45);
+  color: var(--muted);
+  font-size: 11px;
+  z-index: 30;
+  max-width: 320px;
+  pointer-events: none;
+}
+.boot-status.warn {
+  border-color: rgba(234, 179, 8, 0.85);
+}
+.boot-status.bad {
+  border-color: rgba(248, 113, 113, 0.9);
+}

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/style.css
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/style.css
@@ -337,25 +337,3 @@ html, body {
   gap: 8px;
   align-items: center;
 }
-
-/* Boot / startup status indicator */
-.boot-status {
-  position: fixed;
-  bottom: 12px;
-  left: 12px;
-  padding: 6px 10px;
-  background: rgba(15, 23, 42, 0.94);
-  border-radius: 8px;
-  border: 1px solid rgba(122, 162, 247, 0.45);
-  color: var(--muted);
-  font-size: 11px;
-  z-index: 30;
-  max-width: 320px;
-  pointer-events: none;
-}
-.boot-status.warn {
-  border-color: rgba(234, 179, 8, 0.85);
-}
-.boot-status.bad {
-  border-color: rgba(248, 113, 113, 0.9);
-}

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/world/fov.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/world/fov.js
@@ -144,30 +144,42 @@ export function recomputeFOV(ctx) {
     const townLightActive = isTown && (phase === "night" || phase === "dusk" || phase === "dawn");
     const dungeonLightActive = isDungeon; // torches glow regardless of time
 
-    if (townLightActive && Array.isArray(ctx.townProps)) {
-      for (const p of ctx.townProps) {
-        if (!p) continue;
-        const def = propDefFor(p.type);
-        const emits = !!(def && def.properties && def.properties.emitsLight);
-        if (!emits) continue;
+    if (townLightActive) {
+      const lights = Array.isArray(ctx.townLightProps) ? ctx.townLightProps : (Array.isArray(ctx.townProps) ? ctx.townProps : []);
+      if (lights.length) {
+        const px = player.x | 0;
+        const py = player.y | 0;
+        for (const p of lights) {
+          if (!p) continue;
+          const lx = p.x | 0, ly = p.y | 0;
+          if (!ctx.inBounds(lx, ly)) continue;
 
-        const lx = p.x | 0, ly = p.y | 0;
-        if (!ctx.inBounds(lx, ly)) continue;
+          // Distance-based culling: skip lamps far outside player FOV radius.
+          const dx = lx - px;
+          const dy = ly - py;
+          const dist = Math.abs(dx) + Math.abs(dy);
+          const margin = 3;
+          if (dist > radius + margin) continue;
 
-        const baseR = Math.max(2, Math.min(6, Math.floor((radius + 2) / 3))); // default small local glow (typically 3-4)
-        const castR = (def && def.light && typeof def.light.castRadius === "number")
-          ? Math.max(1, Math.min(12, Math.floor(def.light.castRadius)))
-          : baseR;
+          const def = propDefFor(p.type);
+          const emits = !!(def && def.properties && def.properties.emitsLight);
+          if (!emits) continue;
 
-        visible[ly][lx] = true;
-        castLight(lx, ly, 1, 1.0, 0.0, castR, 1, 0, 0, 1, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, 1, 0, 0, -1, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, -1, 0, 0, 1, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, -1, 0, 0, -1, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, 0, 1, 1, 0, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, 0, 1, -1, 0, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, 0, -1, 1, 0, false);
-        castLight(lx, ly, 1, 1.0, 0.0, castR, 0, -1, -1, 0, false);
+          const baseR = Math.max(2, Math.min(6, Math.floor((radius + 2) / 3))); // default small local glow (typically 3-4)
+          const castR = (def && def.light && typeof def.light.castRadius === "number")
+            ? Math.max(1, Math.min(12, Math.floor(def.light.castRadius)))
+            : baseR;
+
+          visible[ly][lx] = true;
+          castLight(lx, ly, 1, 1.0, 0.0, castR, 1, 0, 0, 1, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, 1, 0, 0, -1, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, -1, 0, 0, 1, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, -1, 0, 0, -1, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, 0, 1, 1, 0, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, 0, 1, -1, 0, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, 0, -1, 1, 0, false);
+          castLight(lx, ly, 1, 1.0, 0.0, castR, 0, -1, -1, 0, false);
+        }
       }
     }
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/world/fov.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/world/fov.js
@@ -17,6 +17,13 @@
  */
 
 export function recomputeFOV(ctx) {
+  let _fovPerfStart = null;
+  try {
+    if (typeof performance !== "undefined" && performance && typeof performance.now === "function") {
+      _fovPerfStart = performance.now();
+    }
+  } catch (_) {}
+
   const { fovRadius, player, map, TILES } = ctx;
   const ROWS = map.length;
   const COLS = map[0] ? map[0].length : 0;
@@ -214,6 +221,14 @@ export function recomputeFOV(ctx) {
     }
     // Mark all newly seen enemies as announced
     for (const e of newly) e.announced = true;
+  }
+
+  if (_fovPerfStart != null) {
+    try {
+      const dt = performance.now() - _fovPerfStart;
+      ctx._perfFOVAccum = (ctx._perfFOVAccum || 0) + dt;
+      ctx._perfFOVCount = (ctx._perfFOVCount || 0) + 1;
+    } catch (_) {}
   }
 }
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/worldgen/town_gen.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/worldgen/town_gen.js
@@ -915,6 +915,44 @@ function generate(ctx) {
   // Repair pass: enforce solid building perimeters (convert any non-door/window on borders to WALL)
   repairBuildingPerimeters(ctx, buildings);
 
+  // Precompute town light props (emissive props) for FOV and glow systems
+  (function buildTownLightProps() {
+    try {
+      const props = Array.isArray(ctx.townProps) ? ctx.townProps : [];
+      const out = [];
+      const GD = (typeof window !== "undefined" ? window.GameData : null);
+      const arr = GD && GD.props && Array.isArray(GD.props.props) ? GD.props.props : null;
+      if (!arr || !props.length) {
+        ctx.townLightProps = out;
+        return;
+      }
+      const cache = new Map();
+      function emitsLight(type) {
+        const key = String(type || "").toLowerCase();
+        if (cache.has(key)) return cache.get(key);
+        let def = null;
+        for (let i = 0; i < arr.length; i++) {
+          const e = arr[i];
+          if (String(e.id || "").toLowerCase() === key || String(e.key || "").toLowerCase() === key) {
+            def = e;
+            break;
+          }
+        }
+        const emits = !!(def && def.properties && def.properties.emitsLight);
+        cache.set(key, emits);
+        return emits;
+      }
+      for (const p of props) {
+        if (!p) continue;
+        if (!emitsLight(p.type)) continue;
+        out.push({ x: p.x, y: p.y, type: p.type });
+      }
+      ctx.townLightProps = out;
+    } catch (_) {
+      try { ctx.townLightProps = []; } catch (_) {}
+    }
+  })();
+
   // NPCs via TownAI + special cats + roaming villagers/guards
   populateTownNpcs(ctx, W, H, gate, plaza, townSize, townKind, TOWNCFG, info, rng);
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/worldgen/town_gen.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/worldgen/town_gen.js
@@ -33,6 +33,7 @@ import { placeCaravanStallIfCaravanPresent } from "./town/caravan_stall.js";
 import { placeShopPrefabsStrict } from "./town/prefab_shops.js";
 import { prepareHarborZone, placeHarborPrefabs } from "./town/harbor.js";
 import { ensureHarborAccessibility } from "./town/accessibility.js";
+import { computeTownFlowFields } from "../core/town/flows.js";
 
 function inBounds(ctx, x, y) {
   try {
@@ -914,6 +915,9 @@ function generate(ctx) {
 
   // Repair pass: enforce solid building perimeters (convert any non-door/window on borders to WALL)
   repairBuildingPerimeters(ctx, buildings);
+
+  // Precompute town flow fields (plaza, gate, inn door, harbor band)
+  try { computeTownFlowFields(ctx); } catch (_) {}
 
   // Precompute town light props (emissive props) for FOV and glow systems
   (function buildTownLightProps() {


### PR DESCRIPTION
- Summary: Introduces lightweight performance profiling around Town AI, rendering, and FOV calculations, and makes two small gameplay/logic tweaks to reduce hot-path work and adjust path budgeting based on town size and time of day.
- What changed:
  - ai/town_movement.js: initPathBudget now accounts for town size (small, city, default big) and time-of-day adjustments (night/dusk/dawn). This makes path budgeting more realistic across different town scales.
  - ai/town_runtime.js: dedupeHomeBeds is throttled to run roughly every 20 turns instead of every tick, with a fallback to run immediately if timing info is unavailable. This reduces hot-path work during NPC processing.
  - core/town/runtime.js: around tick, added lightweight performance timing around Town AI execution using performance.now(), accumulating total time and invocation count in ctx (e.g., _perfTownAIAccum, _perfTownAICount).
  - ui/render_town.js: added start-time capture for the town rendering path and accumulate render duration in ctx (_perfTownDrawAccum, _perfTownDrawCount).
  - world/fov.js: added start-time capture for field-of-view recomputation and accumulate duration in ctx (_perfFOVAccum, _perfFOVCount).
- Why this helps:
  - Profiling hooks give visibility into where time is spent (AI, rendering, FOV), making it easier to identify bottlenecks for future optimizations.
  - Throttling bed dedupe reduces repetitive work each tick, improving frame and tick performance without changing final dedup results.
  - Path budget tweak aligns NPC movement budgeting with town size and diurnal phase, potentially improving pacing and resource usage in different world states.
- Testing tips:
  - Play through a few cycles of day/night and different town sizes (small/city/big) to observe NPC behavior changes and ensure no regressions in basic movement.
  - Monitor performance counters subtly via console or debugging hooks if available (ctx._perfTownAIAccum, _perfTownAICount, _perfTownDrawAccum/_Count, _perfFOVAccum/_Count). Ensure they increment and do not crash.
  - Verify that dedupeHomeBeds runs less frequently (roughly every 20 turns) and that bed dedup functionality remains correct.
- Deployment note:
  - This change is instrumentation-heavy and introduces minor behavioral tweaks. It’s ready for review and can be deployed to the next release after local validation and performance testing. 

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/nzuzh20cq9p0](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/nzuzh20cq9p0)
Author: zakker111
