### PR TITLE
Pin town biome to town record and improve region map animal visuals

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
@@ -28,8 +28,12 @@
 - mountain-pass dungeons (A/B linked pair) are currently unreliable: interior portal + normal exit behavior does not consistently send the player to the intended far-side overworld tile; treat mountain-pass dungeon travel as broken for now
 - world generation / infinite overworld gets slow and sluggish after exploring large chunks of the world; investigate performance of infinite_gen + world_runtime expansion and caching when many chunks have been visited
 - sometimes the player can trade with a shopkeeper even when they are not at their shop (e.g., bumping them away from the shop door still opens the shop UI)
-- in some towns, ground/terrain tinting still changes incorrectly or inconsistently (tiles changing biome color unexpectedly)
-- animals/creatures on the Region Map sometimes use odd or incorrect glyphs (verify animal glyph mapping in region map overlays)
+- [FIXED] in some towns, ground/terrain tinting would change incorrectly or inconsistently (tiles changing biome color unexpectedly):
+  - Town biome is now derived once per town and pinned on the core game context using the town's overworld coordinates.
+  - The renderer reuses this pinned biome and no longer re-derives based on player position, so moving inside a town or revisiting it does not flip the ground tint (e.g., GRASS ↔ BEACH ↔ SNOW).
+- [FIXED] animals/creatures on the Region Map sometimes used odd or incorrect glyphs (and could gain square/circle backdrops when attacked):
+  - Region Map now looks up wildlife glyphs and colors from `data/entities/animals.json`.
+  - Neutral and hostile animals are drawn as glyph-only letters (e.g., `d`, `f`, `b`) with no background box, while followers and non-animal enemies still use their square+glyph markers.
 - Quest Board bandit encounter (“Bandits near the farm”) does not always spawn followers correctly:
   - When starting the quest encounter from the `E` marker, followers often log “Your followers cannot find room to stand nearby in this area.” even on relatively open snow/snow-forest tiles.
   - This suggests a mismatch between the camp-style encounter map, region/encounter walkability, and follower spawn radius/occupancy checks for that specific template.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
@@ -1,5 +1,25 @@
 # Game Version History
-Last updated: 2026-01-20 02:30 UTC
+Last updated: 2026-01-27 00:00 UTC
+
+v1.69.0 — Town biome tint stability and Region Map wildlife glyphs
+
+- Town biome tinting stability:
+  - Town biome is now derived once per town using `TownState.deriveTownBiomeFromWorld(ctx, wx, wy)` and pinned on the core game context, keyed by the town’s overworld coordinates (`worldReturnPos`).
+  - World generation (`worldgen/town/layout_core.js`) and TownState both persist the derived biome onto the town’s world record (`rec.biome`), so saves and reloads reuse the same biome per town.
+  - The town renderer (`ui/render/town_base_layer.js`) now resolves and pins the biome on the authoritative game ctx (via `GameAPI.getCtx()`), not on the short‑lived render ctx:
+    - A per‑town map (`_townBiomePinned`) stores `townKey -> biome` for the session.
+    - `ensureTownBiome` reuses this pinned value for each frame instead of re‑deriving based on player position.
+    - The render-time ctx simply mirrors the pinned biome from the core ctx.
+  - Effect: moving inside a town or revisiting it no longer flips the entire ground tint between biomes (e.g., GRASS ↔ BEACH ↔ SNOW); each town now has a stable, deterministic outdoor tint.
+
+- Region Map wildlife glyph/background fix:
+  - Region Map wildlife now consistently uses species glyphs and colors from `data/entities/animals.json`:
+    - `RegionMapRuntime.spawnNeutralAnimals` assigns glyph/color per animal from the JSON definition, with palette fallbacks for safety.
+  - Rendering (`ui/render/region_entities_overlay.js`):
+    - Neutral and hostile animals are rendered as glyph‑only letters (e.g., `d`, `f`, `b`) in species colors, with **no circle or square background**.
+    - Followers and non‑animal enemies keep their square+glyph markers unchanged, preserving existing visual language.
+    - Fire/burning overlays continue to draw above any entity, including animals.
+  - Effect: animals on the Region Map no longer pick up incorrect glyphs or gain a white/light square when first attacked; wildlife remains visually distinct from followers and other enemies.
 
 v1.68.0 — HealthCheck tuning, validation details, and bug tracking updates
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/modes/modes.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/modes/modes.js
@@ -304,6 +304,9 @@ export function enterTownIfOnTile(ctx) {
       ctx.mode = "town";
       // Reset town biome on entry so each town derives or loads its own biome correctly
       try { ctx.townBiome = undefined; } catch (_) {}
+      // Also clear any cached resolver flag so renderers re-run the town biome resolver
+      // for this specific town (while still reusing a pinned biome on the town record).
+      try { ctx._townBiomeResolved = false; } catch (_) {}
       // Also clear outdoor mask so each town rebuilds its own outdoor floor set.
       try { ctx.townOutdoorMask = undefined; } catch (_) {}
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/modes/modes.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/modes/modes.js
@@ -304,6 +304,8 @@ export function enterTownIfOnTile(ctx) {
       ctx.mode = "town";
       // Reset town biome on entry so each town derives or loads its own biome correctly
       try { ctx.townBiome = undefined; } catch (_) {}
+      // Also clear outdoor mask so each town rebuilds its own outdoor floor set.
+      try { ctx.townOutdoorMask = undefined; } catch (_) {}
 
       // Harbor detection for potential port towns (metadata-only at this stage).
       try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/state.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/state.js
@@ -417,15 +417,24 @@ function applyState(ctx, st, x, y) {
   })();
 
   // Ensure town biome is set on load by sampling surrounding world tiles once.
-  // Use shared helper so renderer and runtime agree on the town's biome.
+  // Use shared helper so renderer and runtime agree on the town's biome, and
+  // pin the result on the town record so subsequent visits reuse the same biome.
   try {
     try { ctx.townOutdoorMask = undefined; } catch (_) {}
-    const rec = (ctx.world && Array.isArray(ctx.world.towns)) ? ctx.world.towns.find(t => t && t.x === x && t.y === y) : null;
-    const biome = deriveTownBiomeFromWorld(ctx, x, y);
-    ctx.townBiome = biome || "GRASS";
-    try {
-      if (rec && typeof rec === "object") rec.biome = ctx.townBiome;
-    } catch (_) {}
+
+    const townsArr = (ctx.world && Array.isArray(ctx.world.towns)) ? ctx.world.towns : [];
+    const rec = townsArr.find(t => t && t.x === x && t.y === y) || null;
+
+    // Prefer an existing pinned biome on the town record; only derive when missing.
+    let biome = rec && rec.biome;
+    if (!biome) {
+      biome = deriveTownBiomeFromWorld(ctx, x, y) || "GRASS";
+      try {
+        if (rec && typeof rec === "object" && !rec.biome) rec.biome = biome;
+      } catch (_) {}
+    }
+
+    ctx.townBiome = biome;
     try { ctx._townBiomeResolved = true; } catch (_) {}
   } catch (_) {}
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/region_map/region_map_runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/region_map/region_map_runtime.js
@@ -1328,7 +1328,38 @@ function open(ctx, size) {
         const glyph = (def && def.glyph) ? def.glyph : (typeId && typeId[0]) ? typeId[0] : "?";
         const hp = (def && typeof def.hp === "number") ? def.hp : 3;
         const atk = (def && typeof def.atk === "number") ? def.atk : 0.8;
-        ctx.enemies.push({ x: pos.x, y: pos.y, type: typeId || "animal", glyph, hp, atk, xp: 0, level: 1, faction: "animal", announced: false });
+
+        // Prefer per-species color from animals.json; fall back to generic regionAnimal overlay color.
+        let color = null;
+        try {
+          if (def && typeof def.color === "string" && def.color.trim()) {
+            color = def.color;
+          } else {
+            const pal = (typeof window !== "undefined"
+              && window.GameData
+              && window.GameData.palette
+              && window.GameData.palette.overlays)
+              ? window.GameData.palette.overlays
+              : null;
+            color = (pal && pal.regionAnimal) ? pal.regionAnimal : "#e9d5a1";
+          }
+        } catch (_) {
+          color = "#e9d5a1";
+        }
+
+        ctx.enemies.push({
+          x: pos.x,
+          y: pos.y,
+          type: typeId || "animal",
+          glyph,
+          hp,
+          atk,
+          xp: 0,
+          level: 1,
+          faction: "animal",
+          color,
+          announced: false
+        });
         spawned++;
       }
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render/town_base_layer.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render/town_base_layer.js
@@ -28,57 +28,75 @@ function ensureTownBiome(ctx) {
   try {
     if (!ctx) return;
 
-    const world = ctx.world || {};
-    const towns = (ctx.world && Array.isArray(ctx.world.towns)) ? ctx.world.towns : [];
+    // RenderTown.draw receives a lightweight render context, not the full game
+    // ctx. For stable town biome pinning we must operate on the authoritative
+    // game ctx (via GameAPI.getCtx) and mirror the result back onto the render
+    // ctx. This prevents per-frame re-derivation when the render ctx object is
+    // recreated each draw.
+    let base = ctx;
+    try {
+      if (typeof window !== "undefined" && window.GameAPI && typeof window.GameAPI.getCtx === "function") {
+        const c = window.GameAPI.getCtx();
+        if (c && typeof c === "object") base = c;
+      }
+    } catch (_) {}
+
+    const world = base.world || {};
+    const towns = (base.world && Array.isArray(base.world.towns)) ? base.world.towns : [];
 
     // Resolve a stable key for this town based on its overworld entry coordinates.
     let townKey = null;
     try {
-      if (ctx.worldReturnPos && typeof ctx.worldReturnPos.x === "number" && typeof ctx.worldReturnPos.y === "number") {
-        townKey = `${ctx.worldReturnPos.x | 0},${ctx.worldReturnPos.y | 0}`;
+      if (base.worldReturnPos && typeof base.worldReturnPos.x === "number" && typeof base.worldReturnPos.y === "number") {
+        townKey = `${base.worldReturnPos.x | 0},${base.worldReturnPos.y | 0}`;
       }
     } catch (_) {}
 
-    // Initialize per-town pinned biome map on ctx (in-memory only for this session).
+    // Initialize per-town pinned biome map on the base ctx (in-memory only for this session).
     try {
-      if (!ctx._townBiomePinned || typeof ctx._townBiomePinned !== "object") {
-        ctx._townBiomePinned = Object.create(null);
+      if (!base._townBiomePinned || typeof base._townBiomePinned !== "object") {
+        base._townBiomePinned = Object.create(null);
       }
     } catch (_) {
-      if (!ctx._townBiomePinned || typeof ctx._townBiomePinned !== "object") {
-        ctx._townBiomePinned = ctx._townBiomePinned || {};
+      if (!base._townBiomePinned || typeof base._townBiomePinned !== "object") {
+        base._townBiomePinned = base._townBiomePinned || {};
       }
     }
-    const pinnedMap = ctx._townBiomePinned || null;
+    const pinnedMap = base._townBiomePinned || null;
 
     // 1) If we already have a pinned biome for this townKey, trust it unconditionally.
     if (townKey && pinnedMap && Object.prototype.hasOwnProperty.call(pinnedMap, townKey)) {
       const pinned = pinnedMap[townKey];
       if (pinned) {
+        base.townBiome = pinned;
         ctx.townBiome = pinned;
-      } else if (!ctx.townBiome) {
-        ctx.townBiome = "GRASS";
+      } else {
+        if (!base.townBiome) base.townBiome = "GRASS";
+        if (!ctx.townBiome) ctx.townBiome = base.townBiome;
       }
+      try { base._townBiomeResolved = true; } catch (_) {}
       try { ctx._townBiomeResolved = true; } catch (_) {}
       return;
     }
 
-    // 2) If a previous resolution marked the biome as resolved and ctx.townBiome
+    // 2) If a previous resolution marked the biome as resolved and base.townBiome
     // is already a string, backfill the pin map and return.
-    if (ctx._townBiomeResolved && typeof ctx.townBiome === "string" && ctx.townBiome) {
+    if (base._townBiomeResolved && typeof base.townBiome === "string" && base.townBiome) {
       if (townKey && pinnedMap && !Object.prototype.hasOwnProperty.call(pinnedMap, townKey)) {
-        pinnedMap[townKey] = ctx.townBiome;
+        pinnedMap[townKey] = base.townBiome;
       }
+      ctx.townBiome = base.townBiome;
+      try { ctx._townBiomeResolved = true; } catch (_) {}
       return;
     }
 
     // 3) Fresh resolution: reuse previous logic but also pin the result per town.
     let rec = null;
     let wx = null, wy = null;
-    const hasWRP = !!(ctx.worldReturnPos && typeof ctx.worldReturnPos.x === "number" && typeof ctx.worldReturnPos.y === "number");
+    const hasWRP = !!(base.worldReturnPos && typeof base.worldReturnPos.x === "number" && typeof base.worldReturnPos.y === "number");
     if (hasWRP) {
-      wx = ctx.worldReturnPos.x | 0;
-      wy = ctx.worldReturnPos.y | 0;
+      wx = base.worldReturnPos.x | 0;
+      wy = base.worldReturnPos.y | 0;
       for (let i = 0; i < towns.length; i++) {
         const t = towns[i];
         if (t && (t.x | 0) === wx && (t.y | 0) === wy) { rec = t; break; }
@@ -110,18 +128,18 @@ function ensureTownBiome(ctx) {
       } else if (!hasWRP) {
         const ox = world.originX | 0;
         const oy = world.originY | 0;
-        wx = (ox + (ctx.player ? (ctx.player.x | 0) : 0)) | 0;
-        wy = (oy + (ctx.player ? (ctx.player.y | 0) : 0)) | 0;
+        wx = (ox + (base.player ? (base.player.x | 0) : 0)) | 0;
+        wy = (oy + (base.player ? (base.player.y | 0) : 0)) | 0;
       }
 
       try {
-        const TS = ctx.TownState || (typeof window !== "undefined" ? window.TownState : null);
+        const TS = base.TownState || (typeof window !== "undefined" ? window.TownState : null);
         if (TS && typeof TS.deriveTownBiomeFromWorld === "function" && typeof wx === "number" && typeof wy === "number") {
-          biome = TS.deriveTownBiomeFromWorld(ctx, wx, wy);
+          biome = TS.deriveTownBiomeFromWorld(base, wx, wy);
         }
       } catch (_) {}
 
-      if (!biome) biome = ctx.townBiome || "GRASS";
+      if (!biome) biome = base.townBiome || ctx.townBiome || "GRASS";
 
       // Only write to rec.biome when it was previously unset, so once pinned
       // we never change a town's biome again.
@@ -130,15 +148,18 @@ function ensureTownBiome(ctx) {
       } catch (_) {}
     }
 
-    ctx.townBiome = biome || "GRASS";
+    const finalBiome = biome || "GRASS";
+    base.townBiome = finalBiome;
+    ctx.townBiome = finalBiome;
 
     // Pin this biome for the current townKey so repeated resolutions for this
     // town in this session always reuse the same value even if other heuristics
     // would disagree.
     if (townKey && pinnedMap && !Object.prototype.hasOwnProperty.call(pinnedMap, townKey)) {
-      pinnedMap[townKey] = ctx.townBiome;
+      pinnedMap[townKey] = finalBiome;
     }
 
+    try { base._townBiomeResolved = true; } catch (_) {}
     try { ctx._townBiomeResolved = true; } catch (_) {}
   } catch (_) {}
 }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/worldgen/town/layout_core.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/worldgen/town/layout_core.js
@@ -247,78 +247,53 @@ export function buildBaseTown(ctx) {
   ctx.townPrefabUsage = { houses: [], shops: [], inns: [], plazas: [], caravans: [] };
 
   // Derive and persist the town biome from the overworld around this town's location.
+  // Use TownState.deriveTownBiomeFromWorld when available so worldgen, runtime, and
+  // renderer all share the same heuristic and each town gets a single pinned biome.
   (function deriveTownBiome() {
     try {
-      const WMOD = ctx.World || getMod(ctx, "World");
-      const WT = WMOD && WMOD.TILES ? WMOD.TILES : null;
       const world = ctx.world || {};
-
-      // Helper: get world tile by absolute coords; prefer current window, fall back to generator.
-      function worldTileAtAbs(ax, ay) {
-        const wmap = world.map || null;
-        const ox = world.originX | 0, oy = world.originY | 0;
-        const lx = (ax - ox) | 0, ly = (ay - oy) | 0;
-        if (Array.isArray(wmap) && ly >= 0 && lx >= 0 && ly < wmap.length && lx < (wmap[0] ? wmap[0].length : 0)) {
-          return wmap[ly][lx];
-        }
-        if (world.gen && typeof world.gen.tileAt === "function") return world.gen.tileAt(ax, ay);
-        return null;
-      }
+      const townsArr = (ctx.world && Array.isArray(ctx.world.towns)) ? ctx.world.towns : [];
 
       // Absolute world coords for this town.
-      const wx = (ctx.worldReturnPos && typeof ctx.worldReturnPos.x === "number")
+      let wx = (ctx.worldReturnPos && typeof ctx.worldReturnPos.x === "number")
         ? (ctx.worldReturnPos.x | 0)
         : ((world.originX | 0) + (ctx.player.x | 0));
-      const wy = (ctx.worldReturnPos && typeof ctx.worldReturnPos.y === "number")
+      let wy = (ctx.worldReturnPos && typeof ctx.worldReturnPos.y === "number")
         ? (ctx.worldReturnPos.y | 0)
         : ((world.originY | 0) + (ctx.player.y | 0));
 
-      // Neighborhood sampling around the town tile to find surrounding biome (skip TOWN/DUNGEON/RUINS).
-      let counts = { DESERT: 0, SNOW: 0, BEACH: 0, SWAMP: 0, FOREST: 0, GRASS: 0 };
-      function bump(tile) {
-        if (!WT) return;
-        if (tile === WT.DESERT) counts.DESERT++;
-        else if (tile === WT.SNOW) counts.SNOW++;
-        else if (tile === WT.BEACH) counts.BEACH++;
-        else if (tile === WT.SWAMP) counts.SWAMP++;
-        else if (tile === WT.FOREST) counts.FOREST++;
-        else if (tile === WT.GRASS) counts.GRASS++;
+      // Match the world.towns record for this town if possible.
+      let rec = null;
+      for (let i = 0; i < townsArr.length; i++) {
+        const t = townsArr[i];
+        if (t && (t.x | 0) === wx && (t.y | 0) === wy) { rec = t; break; }
       }
 
-      // Search radius growing rings until we find any biome tiles.
-      const MAX_R = 6;
-      for (let r = 1; r <= MAX_R; r++) {
-        let any = false;
-        for (let dy = -r; dy <= r; dy++) {
-          for (let dx = -r; dx <= r; dx++) {
-            if (Math.max(Math.abs(dx), Math.abs(dy)) !== r) continue; // only outer ring
-            const t = worldTileAtAbs(wx + dx, wy + dy);
-            if (t == null) continue;
-            // Skip POI markers
-            if (WT && (t === WT.TOWN || t === WT.DUNGEON || t === WT.RUINS)) continue;
-            bump(t);
-            any = true;
-          }
-        }
-        // If we have any biome counts after this ring, stop.
-        const total = counts.DESERT + counts.SNOW + counts.BEACH + counts.SWAMP + counts.FOREST + counts.GRASS;
-        if (any && total > 0) break;
+      // Prefer the town record's own coordinates as the sampling anchor when present.
+      if (rec && typeof rec.x === "number" && typeof rec.y === "number") {
+        wx = rec.x | 0;
+        wy = rec.y | 0;
       }
 
-      // Pick the biome with the highest count; tie-break by a fixed priority.
-      const order = ["FOREST", "GRASS", "DESERT", "BEACH", "SNOW", "SWAMP"];
-      let best = "GRASS", bestV = -1;
-      for (const k of order) {
-        const v = counts[k] | 0;
-        if (v > bestV) { bestV = v; best = k; }
-      }
-      ctx.townBiome = best || "GRASS";
-
-      // Persist on world.towns entry if available.
+      let biome = null;
       try {
-        const rec = (ctx.world && Array.isArray(ctx.world.towns)) ? ctx.world.towns.find(t => t && t.x === wx && t.y === wy) : null;
-        if (rec && typeof rec === "object") rec.biome = ctx.townBiome;
-        else if (info && typeof info === "object") info.biome = ctx.townBiome;
+        const TS = ctx.TownState || (typeof window !== "undefined" ? window.TownState : null);
+        if (TS && typeof TS.deriveTownBiomeFromWorld === "function") {
+          biome = TS.deriveTownBiomeFromWorld(ctx, wx, wy);
+        }
+      } catch (_) {}
+
+      if (!biome) biome = "GRASS";
+
+      ctx.townBiome = biome;
+
+      // Persist on world.towns entry if available, but only if it did not already have a biome.
+      try {
+        if (rec && typeof rec === "object" && !rec.biome) {
+          rec.biome = ctx.townBiome;
+        } else if (!rec && info && typeof info === "object" && !info.biome) {
+          info.biome = ctx.townBiome;
+        }
       } catch (_) {}
     } catch (_) {}
   })();


### PR DESCRIPTION
- town enters: clear outdoor mask to force rebuilding of outdoor floor set for town separation (core/modes/modes.js).
- town biome handling: on load, pin the derived biome to the town record so subsequent visits reuse the same biome; only derive when missing, and reset townOutdoorMask beforehand (core/town/state.js).
- region map visuals: enhance color handling for enemies on region map. Enemies now derive color from per-species data (animals.json) or region overlay; fallback to a default color (#e9d5a1); attach color to enemy objects (region_map/region_map_runtime.js).
- region entities overlay: render animals as glyph-only markers with species color, no background; keep follower visuals with a colored backdrop and glyph colored for readability; support color from e.color or palette data; add dynamic fire marker (✦) when on fire (ui/render/region_entities_overlay.js).
- overall: region map now classifies and renders animals distinctly (glyph-focused, color-aware) while preserving existing behaviors for followers and other enemies, improving visual clarity and consistency with per-species data.

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/e3gqm3arrr0m](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/e3gqm3arrr0m)
Author: zakker111
