### PR TITLE
Introduce SandboxRuntime with enter(ctx, options) to boot an isolated sandbox dungeon

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
@@ -5,6 +5,7 @@ High-level snapshot of what the game currently supports and what the player can 
 - For **history / detailed change logs**, see `VERSIONS.md`.
 - For **planned work**, see `TODO.md`.
 - For **known issues and unstable systems**, see `BUGS.md`.
+- Sandbox enemy lab: data-driven enemy/loot testing via **GOD → Enter Sandbox (Dungeon Room)** and **F10**.
 
 This file should describe the **current state**, not the future; update it whenever we add or significantly change features.
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -276,6 +276,15 @@ This file collects planned features, ideas, and technical cleanups that were pre
 
 ## Technical / Cleanup
 
+- [ ] CRITICAL: Enemy depth vs dungeon level
+  - Current enemy HP/ATK/XP curves in `data/entities/enemies.json` are keyed by a conceptual “depth”. The engine historically used `floor`/`depth` for multi-floor dungeons.
+  - The game has since moved to a single-floor dungeon model per run, but some code paths (including sandbox helpers and spawn-by-id flows) still conceptually talk about “depth” when sampling curves.
+  - Update enemy stat resolution to be driven by a clearer “dungeon level” or difficulty band rather than a notional multi-floor depth:
+    - Clarify what “level” means for dungeons/towers in the current design (e.g., world progression, tower tier, or encounter difficulty) and use that consistently when sampling enemy curves.
+    - Avoid implying that there are multiple physical dungeon floors when there is only one active floor per run.
+    - Keep curves and their sampling behavior fully data-driven and centralized so future multi-floor dungeons (if reintroduced) can still plug in cleanly.
+  - Sandbox “Test depth” should be revisited once dungeon level semantics are clarified, to match the real progression axis used by the game.
+
 - [ ] Startup diagnostics & loading visualization
   - Keep startup fast by treating “game becomes playable quickly” as the primary goal and running heavy validations only on demand:
     - Boot-time HealthCheck should remain a lightweight presence/shape pass over modules and data, deferring full schema validation to GOD/dev tools.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
@@ -646,13 +646,7 @@ export function enemiesAct(ctx) {
           raw *= (ctx.critMultiplier ? ctx.critMultiplier(rv) : (1.6 + rv() * 0.4));
         }
         const dmg = ctx.enemyDamageAfterDefense(raw);
-        let finalDmg = dmg;
-        try {
-          if (ctx && ctx.isSandbox && ctx.sandboxFlags && ctx.sandboxFlags.godMode) {
-            finalDmg = 0;
-          }
-        } catch (_) {}
-        player.hp -= finalDmg;
+        player.hp -= dmg;
         try { if (typeof ctx.addBloodDecal === "function") ctx.addBloodDecal(player.x, player.y, isCrit ? 1.4 : 1.0); } catch (_) {}
 
         const attackerName = e.name || Cap(e.type || "enemy");

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
@@ -58,6 +58,12 @@ function hasLOS(ctx, x0, y0, x1, y1) {
 }
 
 export function enemiesAct(ctx) {
+  // Sandbox: allow disabling enemy AI entirely via ctx.sandboxFlags.aiEnabled.
+  try {
+    if (ctx && ctx.isSandbox && ctx.sandboxFlags && ctx.sandboxFlags.aiEnabled === false) {
+      return;
+    }
+  } catch (_) {}
   const { player, enemies } = ctx;
   const U = (ctx && ctx.utils) ? ctx.utils : null;
   // Local RNG value helper: RNGUtils or ctx.rng; deterministic 0.5 when unavailable
@@ -640,7 +646,13 @@ export function enemiesAct(ctx) {
           raw *= (ctx.critMultiplier ? ctx.critMultiplier(rv) : (1.6 + rv() * 0.4));
         }
         const dmg = ctx.enemyDamageAfterDefense(raw);
-        player.hp -= dmg;
+        let finalDmg = dmg;
+        try {
+          if (ctx && ctx.isSandbox && ctx.sandboxFlags && ctx.sandboxFlags.godMode) {
+            finalDmg = 0;
+          }
+        } catch (_) {}
+        player.hp -= finalDmg;
         try { if (typeof ctx.addBloodDecal === "function") ctx.addBloodDecal(player.x, player.y, isCrit ? 1.4 : 1.0); } catch (_) {}
 
         const attackerName = e.name || Cap(e.type || "enemy");

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/ctx.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/ctx.js
@@ -49,6 +49,7 @@ export function attachModules(ctx) {
     if (window.DungeonRuntime) ctx.DungeonRuntime = window.DungeonRuntime;
     if (window.TownRuntime) ctx.TownRuntime = window.TownRuntime;
     if (window.RegionMapRuntime) ctx.RegionMapRuntime = window.RegionMapRuntime;
+    if (window.SandboxRuntime) ctx.SandboxRuntime = window.SandboxRuntime;
     if (window.Modes) ctx.Modes = window.Modes;
     // UI facades
     if (window.UIBridge) ctx.UIBridge = window.UIBridge;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/loot.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/loot.js
@@ -17,7 +17,7 @@ export function generateLoot(ctx, source) {
 }
 
 export function lootHere(ctx) {
-  if (!ctx || (ctx.mode !== "dungeon" && ctx.mode !== "encounter")) return false;
+  if (!ctx || (ctx.mode !== "dungeon" && ctx.mode !== "encounter" && ctx.mode !== "sandbox")) return false;
 
   // Exact-tile only: do not auto-step onto adjacent corpses/chests. Looting and flavor apply only if standing on the body tile.
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/movement.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/movement.js
@@ -5,8 +5,8 @@ import { getMod } from "../../utils/access.js";
 import { maybeEnterMountainPass } from "./transitions.js";
 
 export function tryMoveDungeon(ctx, dx, dy) {
-  if (!ctx || (ctx.mode !== "dungeon" && ctx.mode !== "encounter")) return false;
-  const advanceTurn = (ctx.mode === "dungeon"); // in encounter, the orchestrator advances the turn after syncing
+  if (!ctx || (ctx.mode !== "dungeon" && ctx.mode !== "encounter" && ctx.mode !== "sandbox")) return false;
+  const advanceTurn = (ctx.mode === "dungeon" || ctx.mode === "sandbox"); // in encounter, the orchestrator advances the turn after syncing
 
   // Dazed: skip action if dazedTurns > 0
   try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/state.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/state.js
@@ -10,6 +10,7 @@ export function keyFromWorldPos(x, y) {
 }
 
 export function save(ctx, logOnce = false) {
+  if (!ctx || ctx.isSandbox) return;
   if (ctx.DungeonState && typeof ctx.DungeonState.save === "function") {
     ctx.DungeonState.save(ctx);
     return;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/tick.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/dungeon/tick.js
@@ -2,7 +2,7 @@
  * Dungeon tick (Phase 3 extraction): per-turn processing in dungeon/encounter.
  */
 export function tick(ctx) {
-  if (!ctx || (ctx.mode !== "dungeon" && ctx.mode !== "encounter")) return false;
+  if (!ctx || (ctx.mode !== "dungeon" && ctx.mode !== "encounter" && ctx.mode !== "sandbox")) return false;
   // Enemies act via AI
   try {
     const AIH = ctx.AI || (typeof window !== "undefined" ? window.AI : null);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/game_god.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/game_god.js
@@ -20,6 +20,7 @@ import { attachGlobal } from "../../utils/global.js";
  * - setAlwaysCritFacade(ctx, v), setCritPartFacade(ctx, part)
  * - godSpawnEnemyNearbyFacade(ctx, count), godSpawnItemsFacade(ctx, count)
  * - godHealFacade(ctx), godSpawnStairsHereFacade(ctx)
+ * - godSpawnEnemyByIdFacade?(ctx, id, count)
  */
 export function godActions(opts) {
   return {
@@ -103,6 +104,20 @@ export function godActions(opts) {
       try {
         if (opts && typeof opts.log === "function") {
           opts.log("GOD: spawnEnemyNearby not available.", "warn");
+        }
+      } catch (_) {}
+      return false;
+    },
+    godSpawnEnemyById(id, count = 1) {
+      try {
+        if (opts && typeof opts.godSpawnEnemyByIdFacade === "function") {
+          const ok = opts.godSpawnEnemyByIdFacade(opts.ctx, id, count);
+          if (ok) return true;
+        }
+      } catch (_) {}
+      try {
+        if (opts && typeof opts.log === "function") {
+          opts.log("GOD: spawnEnemyById not available.", "warn");
         }
       } catch (_) {}
       return false;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/game_ui_bridge.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/game_ui_bridge.js
@@ -279,7 +279,8 @@ export function setupInputBridge(opts) {
     toggleSandboxPanel: () => {
       try {
         const ctx = getCtx && getCtx();
-        if (!ctx || !ctx.isSandbox) return;
+        // Sandbox mode is indicated by ctx.mode === "sandbox"
+        if (!ctx || ctx.mode !== "sandbox") return;
         // Prefer SandboxPanel via UI module when available
         if (UIH && UIH.SandboxPanel && typeof UIH.SandboxPanel.isOpen === "function") {
           const open = UIH.SandboxPanel.isOpen();

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/game_ui_bridge.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/game_ui_bridge.js
@@ -45,6 +45,9 @@ export function setupInputBridge(opts) {
   const I = modHandle("Input");
   if (!I || typeof I.init !== "function") return;
 
+  const UIO = modHandle("UIOrchestration");
+  const UIH = modHandle("UI");
+
   I.init({
     // state queries
     isDead: () => {
@@ -271,6 +274,26 @@ export function setupInputBridge(opts) {
     adjustFov: (delta) => {
       try {
         if (typeof adjustFov === "function") adjustFov(delta);
+      } catch (_) {}
+    },
+    toggleSandboxPanel: () => {
+      try {
+        const ctx = getCtx && getCtx();
+        if (!ctx || !ctx.isSandbox) return;
+        // Prefer SandboxPanel via UI module when available
+        if (UIH && UIH.SandboxPanel && typeof UIH.SandboxPanel.isOpen === "function") {
+          const open = UIH.SandboxPanel.isOpen();
+          if (open && typeof UIH.SandboxPanel.hide === "function") UIH.SandboxPanel.hide();
+          else if (!open && typeof UIH.SandboxPanel.show === "function") UIH.SandboxPanel.show();
+          return;
+        }
+        // Fallback via global
+        const SP = (typeof window !== "undefined" ? window.SandboxPanel : null);
+        if (SP && typeof SP.isOpen === "function") {
+          const open = SP.isOpen();
+          if (open && typeof SP.hide === "function") SP.hide();
+          else if (!open && typeof SP.show === "function") SP.show();
+        }
       } catch (_) {}
     },
   });

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/turn_loop.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/engine/turn_loop.js
@@ -80,7 +80,7 @@ export function tick(ctx) {
 
   // Mode-specific progression
   try {
-    if (ctx.mode === "dungeon") {
+    if (ctx.mode === "dungeon" || ctx.mode === "sandbox") {
       const DR = modHandle(ctx, "DungeonRuntime");
       if (DR && typeof DR.tick === "function") DR.tick(ctx);
     } else if (ctx.mode === "town") {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -976,6 +976,30 @@ import "./sandbox/runtime.js";
     return [];
   }
 
+  // Enter a small sandbox dungeon room for focused testing (no persistence).
+  // This mutates a ctx snapshot via SandboxRuntime then syncs it back into the
+  // orchestrator using applyCtxSyncAndRefresh so mode/map/visibility are all
+  // updated consistently.
+  function enterSandboxRoom() {
+    try {
+      const c = getCtx();
+      if (!c) return false;
+      const SR = (c.SandboxRuntime) || (typeof window !== "undefined" ? window.SandboxRuntime : null);
+      if (!SR || typeof SR.enter !== "function") {
+        try { log("GOD: SandboxRuntime module not available; sandbox entry disabled.", "warn"); } catch (_) {}
+        return false;
+      }
+      SR.enter(c, { scenario: "dungeon_room" });
+      // Sync mutated ctx back into local orchestrator state and refresh visuals.
+      try {
+        applyCtxSyncAndRefresh(c);
+      } catch (_) {}
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   
   
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -653,6 +653,9 @@ import "./sandbox/runtime.js";
         sandboxEnemyOverrides = Object.create(null);
       } catch (_) {}
       applyCtxSyncAndRefresh(ctx);
+      try {
+        log("Sandbox: Entered dungeon test room. Press F10 for Sandbox Controls panel.", "info");
+      } catch (_) {}
       return true;
     } catch (e) {
       try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -1358,6 +1358,7 @@ import "./sandbox/runtime.js";
       getClock,
       log,
       applyCtxSyncAndRefresh,
+      enterSandboxRoom: () => enterSandboxRoom(),
     });
   }
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -100,6 +100,8 @@ import {
 import { setupInputBridge, initUIHandlersBridge } from "./engine/game_ui_bridge.js";
 // Side-effect import to ensure FollowersItems attaches itself to window.FollowersItems
 import "./followers_items.js";
+// Side-effect import to ensure SandboxRuntime attaches itself to window.SandboxRuntime
+import "./sandbox/runtime.js";
 
   // Runtime configuration (loaded via GameData.config via core/game_config.js)
   const CFG = getRawConfig();

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -266,7 +266,7 @@ import "./sandbox/runtime.js";
       dungeonExitAt,
       // camera
       camera,
-      getCamera: () =&gt; camera,
+      getCamera: () => camera,
       // dungeon info
       dungeon: currentDungeon,
       dungeonInfo: currentDungeon,
@@ -280,7 +280,7 @@ import "./sandbox/runtime.js";
       sandboxFlags,
       sandboxEnemyOverrides,
       // Perf stats for HUD overlay (smoothed via EMA when available)
-      getPerfStats: () =&gt; perfGetPerfStats(),
+      getPerfStats: () => perfGetPerfStats(),
       requestDraw,
       log,
       isWalkable, inBounds,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -624,6 +624,30 @@ import "./sandbox/runtime.js";
     applyCtxSyncAndRefresh(ctx);
   }
 
+  // Enter a small sandbox dungeon-style room for focused testing (no persistence).
+  function enterSandboxRoom() {
+    try {
+      const ctx = getCtx();
+      if (!ctx) return false;
+      const SR = ctx.SandboxRuntime || modHandle("SandboxRuntime");
+      if (!SR || typeof SR.enter !== "function") {
+        log("GOD: SandboxRuntime.enter not available; sandbox mode disabled.", "warn");
+        return false;
+      }
+      // Mutate ctx into sandbox mode and let orchestrator sync + refresh.
+      SR.enter(ctx, { scenario: "dungeon_room" });
+      applyCtxSyncAndRefresh(ctx);
+      return true;
+    } catch (e) {
+      try {
+        log("GOD: Sandbox entry failed; see console for details.", "warn");
+        // eslint-disable-next-line no-console
+        console.error(e);
+      } catch (_) {}
+      return false;
+    }
+  }
+
   
 
   

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game.js
@@ -976,30 +976,6 @@ import "./sandbox/runtime.js";
     return [];
   }
 
-  // Enter a small sandbox dungeon room for focused testing (no persistence).
-  // This mutates a ctx snapshot via SandboxRuntime then syncs it back into the
-  // orchestrator using applyCtxSyncAndRefresh so mode/map/visibility are all
-  // updated consistently.
-  function enterSandboxRoom() {
-    try {
-      const c = getCtx();
-      if (!c) return false;
-      const SR = (c.SandboxRuntime) || (typeof window !== "undefined" ? window.SandboxRuntime : null);
-      if (!SR || typeof SR.enter !== "function") {
-        try { log("GOD: SandboxRuntime module not available; sandbox entry disabled.", "warn"); } catch (_) {}
-        return false;
-      }
-      SR.enter(c, { scenario: "dungeon_room" });
-      // Sync mutated ctx back into local orchestrator state and refresh visuals.
-      try {
-        applyCtxSyncAndRefresh(c);
-      } catch (_) {}
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
-
   
   
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api.js
@@ -615,6 +615,16 @@ export function create(ctx) {
 
     // GOD helpers
     spawnEnemyNearby: (count = 1) => { try { ctx.godSpawnEnemyNearby((Number(count) || 0) | 0 || 1); return true; } catch(_) { return false; } },
+    spawnEnemyById: (id, count = 1) => {
+      try {
+        const n = (Number(count) || 0) | 0 || 1;
+        if (typeof ctx.godSpawnEnemyById === "function") {
+          ctx.godSpawnEnemyById(String(id || ""), n);
+          return true;
+        }
+      } catch (_) {}
+      return false;
+    },
     spawnItems: (count = 3) => { try { ctx.godSpawnItems((Number(count) || 0) | 0 || 3); return true; } catch(_) { return false; } },
     addPotionToInventory: (heal, name) => { try { ctx.addPotionToInventory((Number(heal) || 0) || 3, String(name || "")); return true; } catch(_) { return false; } },
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api.js
@@ -632,17 +632,22 @@ export function create(ctx) {
           } catch (_) {}
           return false;
         }
-        // Mutate ctx into sandbox mode; let StateSync apply orchestrator sync.
+        // Mutate ctx into sandbox mode (local view first).
         SR.enter(c, { scenario: "dungeon_room" });
+        // Let the orchestrator sync mutated ctx back into its own state and refresh visuals.
         try {
-          const SS = c.StateSync || getMod(c, "StateSync");
-          if (SS && typeof SS.applyAndRefresh === "function") {
-            SS.applyAndRefresh(c, {});
+          if (typeof ctx.applyCtxSyncAndRefresh === "function") {
+            ctx.applyCtxSyncAndRefresh(c);
           } else {
-            if (typeof c.updateCamera === "function") c.updateCamera();
-            if (typeof c.recomputeFOV === "function") c.recomputeFOV();
-            if (typeof c.updateUI === "function") c.updateUI();
-            if (typeof c.requestDraw === "function") c.requestDraw();
+            const SS = c.StateSync || getMod(c, "StateSync");
+            if (SS && typeof SS.applyAndRefresh === "function") {
+              SS.applyAndRefresh(c, {});
+            } else {
+              if (typeof c.updateCamera === "function") c.updateCamera();
+              if (typeof c.recomputeFOV === "function") c.recomputeFOV();
+              if (typeof c.updateUI === "function") c.updateUI();
+              if (typeof c.requestDraw === "function") c.requestDraw();
+            }
           }
         } catch (_) {}
         return true;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api.js
@@ -621,36 +621,8 @@ export function create(ctx) {
     // Enter a small sandbox dungeon room for focused testing (no persistence).
     enterSandboxRoom: () => {
       try {
-        const c = (typeof ctx.getCtx === "function") ? ctx.getCtx() : ctx;
-        if (!c) return false;
-        const SR =
-          (c && c.SandboxRuntime) ||
-          (typeof window !== "undefined" ? window.SandboxRuntime : null);
-        if (!SR || typeof SR.enter !== "function") {
-          try {
-            if (c.log) c.log("GOD: SandboxRuntime.enter not available (sandbox module missing).", "warn");
-          } catch (_) {}
-          return false;
-        }
-        // Mutate ctx into sandbox mode (local view first).
-        SR.enter(c, { scenario: "dungeon_room" });
-        // Let the orchestrator sync mutated ctx back into its own state and refresh visuals.
-        try {
-          if (typeof ctx.applyCtxSyncAndRefresh === "function") {
-            ctx.applyCtxSyncAndRefresh(c);
-          } else {
-            const SS = c.StateSync || getMod(c, "StateSync");
-            if (SS && typeof SS.applyAndRefresh === "function") {
-              SS.applyAndRefresh(c, {});
-            } else {
-              if (typeof c.updateCamera === "function") c.updateCamera();
-              if (typeof c.recomputeFOV === "function") c.recomputeFOV();
-              if (typeof c.updateUI === "function") c.updateUI();
-              if (typeof c.requestDraw === "function") c.requestDraw();
-            }
-          }
-        } catch (_) {}
-        return true;
+        if (!ctx.enterSandboxRoom) return false;
+        return !!ctx.enterSandboxRoom();
       } catch (_) { return false; }
     },
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api_bootstrap.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api_bootstrap.js
@@ -202,15 +202,7 @@ export function buildGameAPIImpl(deps) {
       setAlwaysCrit: (v) => setAlwaysCrit(v),
       setCritPart: (part) => setCritPart(part),
       godSpawnEnemyNearby: (count) => godSpawnEnemyNearby(count),
-      spawnEnemyById: (id, count) => {
-        try {
-          return typeof godSpawnEnemyById === "function"
-            ? !!godSpawnEnemyById(id, count)
-            : false;
-        } catch (_) {
-          return false;
-        }
-      },
+      godSpawnEnemyById: (id, count) => godSpawnEnemyById(id, count),
       godSpawnItems: (count) => godSpawnItems(count),
       generateLoot: (source) => generateLoot(source),
       getClock: () => getClock(),

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api_bootstrap.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api_bootstrap.js
@@ -89,9 +89,18 @@ export function buildGameAPIImpl(deps) {
       generateLoot,
       getClock,
       log,
+      enterSandboxRoom,
     } = deps;
 
     window.GameAPI = window.GameAPIBuilder.create({
+      // Orchestrator sync helper (exposed so helpers like sandbox can request a full ctx→engine sync).
+      applyCtxSyncAndRefresh: (ctx) => {
+        try {
+          if (typeof deps.applyCtxSyncAndRefresh === "function") {
+            deps.applyCtxSyncAndRefresh(ctx);
+          }
+        } catch (_) {}
+      },
       getMode: () => getMode(),
       getWorld: () => getWorld(),
       getPlayer: () => getPlayer(),
@@ -197,6 +206,7 @@ export function buildGameAPIImpl(deps) {
       getClock: () => getClock(),
       getCtx: () => getCtx(),
       log: (msg, type) => log(msg, type),
+      enterSandboxRoom: () => enterSandboxRoom(),
     });
   } catch (_) {}
 }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api_bootstrap.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_api_bootstrap.js
@@ -85,6 +85,7 @@ export function buildGameAPIImpl(deps) {
       setAlwaysCrit,
       setCritPart,
       godSpawnEnemyNearby,
+      godSpawnEnemyById,
       godSpawnItems,
       generateLoot,
       getClock,
@@ -201,6 +202,15 @@ export function buildGameAPIImpl(deps) {
       setAlwaysCrit: (v) => setAlwaysCrit(v),
       setCritPart: (part) => setCritPart(part),
       godSpawnEnemyNearby: (count) => godSpawnEnemyNearby(count),
+      spawnEnemyById: (id, count) => {
+        try {
+          return typeof godSpawnEnemyById === "function"
+            ? !!godSpawnEnemyById(id, count)
+            : false;
+        } catch (_) {
+          return false;
+        }
+      },
       godSpawnItems: (count) => godSpawnItems(count),
       generateLoot: (source) => generateLoot(source),
       getClock: () => getClock(),

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_god_bridge.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/game_god_bridge.js
@@ -13,6 +13,7 @@ import {
   godSpawnItems as godSpawnItemsFacade,
   godHeal as godHealFacade,
   godSpawnStairsHere as godSpawnStairsHereFacade,
+  godSpawnEnemyById as godSpawnEnemyByIdFacade,
 } from "./god/facade.js";
 
 /**
@@ -48,6 +49,7 @@ export function createGodBridge(deps) {
       godSpawnItemsFacade,
       godHealFacade,
       godSpawnStairsHereFacade,
+      godSpawnEnemyByIdFacade,
     });
   }
 
@@ -95,6 +97,12 @@ export function createGodBridge(deps) {
     actions.godSpawnEnemyNearby(count);
   }
 
+  function godSpawnEnemyById(id, count = 1) {
+    const ctx = getCtx();
+    const actions = makeGodActions(ctx);
+    actions.godSpawnEnemyById(id, count);
+  }
+
   function applySeed(seedUint32) {
     if (typeof deps.applySeed === "function") {
       deps.applySeed(seedUint32);
@@ -127,6 +135,7 @@ export function createGodBridge(deps) {
     godSpawnStairsHere,
     godSpawnItems,
     godSpawnEnemyNearby,
+    godSpawnEnemyById,
     applySeed,
     rerollSeed,
     restartGame,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/controls.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/controls.js
@@ -45,6 +45,13 @@ export function spawnEnemyNearby(getCtx, count = 1) {
   ctx.log("GOD: spawnEnemyNearby not available.", "warn");
 }
 
+export function spawnEnemyById(getCtx, id, count = 1) {
+  const ctx = getCtx();
+  const G = (ctx.God || (typeof window !== "undefined" ? window.God : null));
+  if (G && typeof G.spawnEnemyById === "function") return G.spawnEnemyById(ctx, id, count);
+  ctx.log("GOD: spawnEnemyById not available.", "warn");
+}
+
 export function setAlwaysCrit(getCtx, enabled) {
   const ctx = getCtx();
   const G = (ctx.God || (typeof window !== "undefined" ? window.God : null));

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/controls.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/controls.js
@@ -138,6 +138,7 @@ if (typeof window !== "undefined") {
     spawnStairsHere,
     spawnItems,
     spawnEnemyNearby,
+    spawnEnemyById,
     setAlwaysCrit,
     setCritPart,
     applySeed,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/facade.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/facade.js
@@ -72,6 +72,7 @@ if (typeof window !== "undefined") {
     setAlwaysCrit,
     setCritPart,
     godSpawnEnemyNearby,
+    godSpawnEnemyById,
     godSpawnItems,
     godHeal,
     godSpawnStairsHere

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/facade.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/facade.js
@@ -30,6 +30,15 @@ export function godSpawnEnemyNearby(ctx, count = 1) {
   return false;
 }
 
+export function godSpawnEnemyById(ctx, id, count = 1) {
+  const GC = getMod(ctx, "GodControls");
+  if (GC && typeof GC.spawnEnemyById === "function") {
+    GC.spawnEnemyById(() => ctx, id, count);
+    return true;
+  }
+  return false;
+}
+
 export function godSpawnItems(ctx, count = 3) {
   const GC = getMod(ctx, "GodControls");
   if (GC && typeof GC.spawnItems === "function") {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/handlers.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/handlers.js
@@ -61,6 +61,11 @@ export function install(getCtx) {
               if (typeof c.requestDraw === "function") c.requestDraw();
             }
           } catch (_) {}
+          try {
+            if (c && typeof c.log === "function") {
+              c.log("Sandbox: Entered dungeon test room. Press F10 for Sandbox Controls panel.", "info");
+            }
+          } catch (_) {}
           return;
         }
       } catch (_) {}

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/handlers.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/god/handlers.js
@@ -34,6 +34,38 @@ export function install(getCtx) {
       if (G && typeof G.heal === "function") { G.heal(getCtx()); return; }
       const c = getCtx(); c.log("GOD: heal not available.", "warn");
     },
+    onGodEnterSandbox: () => {
+      const c = getCtx();
+      try {
+        const GA = (typeof window !== "undefined" ? window.GameAPI : null);
+        if (GA && typeof GA.enterSandboxRoom === "function") {
+          const ok = GA.enterSandboxRoom();
+          if (!ok && c && c.log) {
+            c.log("GOD: Sandbox entry failed (enterSandboxRoom returned false).", "warn");
+          }
+          return;
+        }
+      } catch (_) {}
+      try {
+        const SR = (c && c.SandboxRuntime) || (typeof window !== "undefined" ? window.SandboxRuntime : null);
+        if (SR && typeof SR.enter === "function") {
+          SR.enter(c, { scenario: "dungeon_room" });
+          try {
+            const SS = c.StateSync || (typeof window !== "undefined" && window.StateSync ? window.StateSync : null);
+            if (SS && typeof SS.applyAndRefresh === "function") {
+              SS.applyAndRefresh(c, {});
+            } else {
+              if (typeof c.updateCamera === "function") c.updateCamera();
+              if (typeof c.recomputeFOV === "function") c.recomputeFOV();
+              if (typeof c.updateUI === "function") c.updateUI();
+              if (typeof c.requestDraw === "function") c.requestDraw();
+            }
+          } catch (_) {}
+          return;
+        }
+      } catch (_) {}
+      try { c && c.log && c.log("GOD: SandboxRuntime module not available; sandbox entry disabled.", "warn"); } catch (_) {}
+    },
     onGodSpawn: () => {
       if (GC && typeof GC.spawnItems === "function") { GC.spawnItems(() => getCtx(), 3); return; }
       if (G && typeof G.spawnItems === "function") { G.spawnItems(getCtx(), 3); return; }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/input.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/input.js
@@ -178,6 +178,15 @@ export function init(handlers) {
       return;
     }
 
+    // Sandbox controls toggle (F10)
+    if (e.key === "F10") {
+      e.preventDefault();
+      if (_handlers.toggleSandboxPanel) {
+        _handlers.toggleSandboxPanel();
+      }
+      return;
+    }
+
     // Region Map key disabled (M does nothing)
 
     // Help / Controls panel (F1)

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/modes/actions.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/modes/actions.js
@@ -319,7 +319,7 @@ export function doAction(ctx) {
     return true;
   }
 
-  if (ctx.mode === "dungeon") {
+  if (ctx.mode === "dungeon" || ctx.mode === "sandbox") {
     const isTowerDungeon =
       !!(ctx.towerRun && ctx.towerRun.kind === "tower") ||
       !!(ctx.dungeonInfo && typeof ctx.dungeonInfo.kind === "string" && String(ctx.dungeonInfo.kind).toLowerCase() === "tower");
@@ -484,7 +484,7 @@ export function loot(ctx) {
     return true;
   }
 
-  if (ctx.mode === "dungeon") {
+  if (ctx.mode === "dungeon" || ctx.mode === "sandbox") {
     // Prefer centralized return flow
     try {
       if (ctx.DungeonRuntime && typeof ctx.DungeonRuntime.returnToWorldIfAtExit === "function") {
@@ -525,7 +525,7 @@ export function descend(ctx) {
     // Reuse action to enter town/dungeon if on appropriate tile
     return doAction(ctx);
   }
-  if (ctx.mode === "dungeon") {
+  if (ctx.mode === "dungeon" || ctx.mode === "sandbox") {
     ctx.log("This dungeon has no deeper levels. Return to the entrance (the hole '>') and press G to leave.", "info");
     return true;
   }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/movement.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/movement.js
@@ -63,7 +63,7 @@ export function fastForwardMinutes(ctx, mins) {
 
 export function brace(ctx) {
   if (!ctx || !ctx.player) return;
-  if (ctx.mode !== "dungeon") {
+  if (ctx.mode !== "dungeon" && ctx.mode !== "sandbox") {
     try { ctx.log && ctx.log("You can brace only in the dungeon.", "info"); } catch (_) {}
     try { if (typeof ctx.turn === "function") ctx.turn(); } catch (_) {}
     return;
@@ -93,7 +93,7 @@ export function descendIfPossible(ctx) {
     try { if (typeof ctx.doAction === "function") ctx.doAction(); } catch (_) {}
     return true;
   }
-  if (ctx.mode === "dungeon") {
+  if (ctx.mode === "dungeon" || ctx.mode === "sandbox") {
     try {
       const MZ = mod("Messages");
       if (MZ && typeof MZ.log === "function") {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
@@ -17,9 +17,9 @@ import { attachGlobal } from "../../utils/global.js";
 function makeBoolGrid(rows, cols, value) {
   const v = !!value;
   const out = new Array(rows);
-  for (let y = 0; y &lt; rows; y++) {
+  for (let y = 0; y < rows; y++) {
     const row = new Array(cols);
-    for (let x = 0; x &lt; cols; x++) row[x] = v;
+    for (let x = 0; x < cols; x++) row[x] = v;
     out[y] = row;
   }
   return out;
@@ -30,15 +30,15 @@ function makeBoolGrid(rows, cols, value) {
  * Uses ctx.TILES when available; falls back to numeric 0/1 if tiles are missing.
  */
 function buildRoomMap(ctx, cols, rows) {
-  const T = ctx &amp;&amp; ctx.TILES ? ctx.TILES : null;
-  const WALL = T &amp;&amp; typeof T.WALL !== "undefined" ? T.WALL : 1;
-  const FLOOR = T &amp;&amp; typeof T.FLOOR !== "undefined" ? T.FLOOR : 0;
+  const T = ctx && ctx.TILES ? ctx.TILES : null;
+  const WALL = T && typeof T.WALL !== "undefined" ? T.WALL : 1;
+  const FLOOR = T && typeof T.FLOOR !== "undefined" ? T.FLOOR : 0;
 
   const map = new Array(rows);
-  for (let y = 0; y &lt; rows; y++) {
+  for (let y = 0; y < rows; y++) {
     const row = new Array(cols);
     const edgeY = y === 0 || y === rows - 1;
-    for (let x = 0; x &lt; cols; x++) {
+    for (let x = 0; x < cols; x++) {
       const edgeX = x === 0 || x === cols - 1;
       // Perimeter walls, interior floor
       row[x] = (edgeX || edgeY) ? WALL : FLOOR;
@@ -57,8 +57,8 @@ function buildRoomMap(ctx, cols, rows) {
  */
 export function enter(ctx, options = {}) {
   if (!ctx) return;
-  const cols = (options &amp;&amp; options.cols) || 30;
-  const rows = (options &amp;&amp; options.rows) || 20;
+  const cols = (options && options.cols) || 30;
+  const rows = (options && options.rows) || 20;
 
   const map = buildRoomMap(ctx, cols, rows);
   const seen = makeBoolGrid(rows, cols, false);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
@@ -70,7 +70,6 @@ export function enter(ctx, options = {}) {
   ctx.sandboxFlags = ctx.sandboxFlags || {};
   ctx.sandboxFlags.fovEnabled = true;
   ctx.sandboxFlags.aiEnabled = true;
-  ctx.sandboxPanelOpen = false;
 
   // Replace local map/visibility. These arrays are shared with core/game.js
   // via getCtx(), so downstream modules will see the updated room.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
@@ -1,0 +1,112 @@
+/**
+ * SandboxRuntime: experimental sandbox mode room for focused testing.
+ *
+ * Exports (ESM + window.SandboxRuntime):
+ * - enter(ctx, options)
+ *
+ * Notes:
+ * - Step 1 MVP: only supports entering a small self-contained dungeon-style room.
+ * - Later steps will add spawn helpers, flags, and panel integration.
+ */
+
+import { attachGlobal } from "../../utils/global.js";
+
+/**
+ * Allocate a rows x cols boolean grid, initialized to the given value.
+ */
+function makeBoolGrid(rows, cols, value) {
+  const v = !!value;
+  const out = new Array(rows);
+  for (let y = 0; y &lt; rows; y++) {
+    const row = new Array(cols);
+    for (let x = 0; x &lt; cols; x++) row[x] = v;
+    out[y] = row;
+  }
+  return out;
+}
+
+/**
+ * Build a simple rectangular dungeon room: walls around the border, floor inside.
+ * Uses ctx.TILES when available; falls back to numeric 0/1 if tiles are missing.
+ */
+function buildRoomMap(ctx, cols, rows) {
+  const T = ctx &amp;&amp; ctx.TILES ? ctx.TILES : null;
+  const WALL = T &amp;&amp; typeof T.WALL !== "undefined" ? T.WALL : 1;
+  const FLOOR = T &amp;&amp; typeof T.FLOOR !== "undefined" ? T.FLOOR : 0;
+
+  const map = new Array(rows);
+  for (let y = 0; y &lt; rows; y++) {
+    const row = new Array(cols);
+    const edgeY = y === 0 || y === rows - 1;
+    for (let x = 0; x &lt; cols; x++) {
+      const edgeX = x === 0 || x === cols - 1;
+      // Perimeter walls, interior floor
+      row[x] = (edgeX || edgeY) ? WALL : FLOOR;
+    }
+    map[y] = row;
+  }
+  return map;
+}
+
+/**
+ * Enter sandbox mode by replacing the active map with a small test room.
+ *
+ * This does NOT attempt to save/restore previous game state; it is an
+ * isolated developer tool. Exiting back to a normal run is handled by
+ * the caller (e.g., via the existing restart/new-game flow).
+ */
+export function enter(ctx, options = {}) {
+  if (!ctx) return;
+  const cols = (options &amp;&amp; options.cols) || 30;
+  const rows = (options &amp;&amp; options.rows) || 20;
+
+  const map = buildRoomMap(ctx, cols, rows);
+  const seen = makeBoolGrid(rows, cols, false);
+  const visible = makeBoolGrid(rows, cols, false);
+
+  // Mark mode + simple flags so other systems can detect sandbox.
+  ctx.mode = "sandbox";
+  ctx.isSandbox = true;
+  ctx.sandboxFlags = ctx.sandboxFlags || {};
+  ctx.sandboxFlags.fovEnabled = true;
+  ctx.sandboxFlags.aiEnabled = true;
+  ctx.sandboxFlags.godMode = true;
+  ctx.sandboxPanelOpen = false;
+
+  // Replace local map/visibility. These arrays are shared with core/game.js
+  // via getCtx(), so downstream modules will see the updated room.
+  ctx.map = map;
+  ctx.seen = seen;
+  ctx.visible = visible;
+
+  // Clear runtime collections specific to the current map.
+  ctx.enemies = Array.isArray(ctx.enemies) ? [] : [];
+  ctx.npcs = Array.isArray(ctx.npcs) ? [] : [];
+  ctx.townProps = Array.isArray(ctx.townProps) ? [] : [];
+  ctx.corpses = Array.isArray(ctx.corpses) ? [] : [];
+  ctx.dungeonProps = Array.isArray(ctx.dungeonProps) ? [] : [];
+  ctx.decals = Array.isArray(ctx.decals) ? [] : [];
+
+  // Place player roughly at the center of the room.
+  if (ctx.player) {
+    ctx.player.x = (cols / 2) | 0;
+    ctx.player.y = (rows / 2) | 0;
+  }
+
+  // Let existing helpers rebuild FOV/camera/UI if present.
+  try {
+    if (typeof ctx.recomputeFOV === "function") ctx.recomputeFOV();
+  } catch (_) {}
+  try {
+    if (typeof ctx.updateCamera === "function") ctx.updateCamera();
+  } catch (_) {}
+  try {
+    if (typeof ctx.updateUI === "function") ctx.updateUI();
+  } catch (_) {}
+  try {
+    if (typeof ctx.requestDraw === "function") ctx.requestDraw();
+  } catch (_) {}
+}
+
+// Back-compat: attach to window so Ctx.attachModules can pick it up later.
+attachGlobal("SandboxRuntime", { enter });

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/sandbox/runtime.js
@@ -70,7 +70,6 @@ export function enter(ctx, options = {}) {
   ctx.sandboxFlags = ctx.sandboxFlags || {};
   ctx.sandboxFlags.fovEnabled = true;
   ctx.sandboxFlags.aiEnabled = true;
-  ctx.sandboxFlags.godMode = true;
   ctx.sandboxPanelOpen = false;
 
   // Replace local map/visibility. These arrays are shared with core/game.js

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/state.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/core/town/state.js
@@ -192,7 +192,10 @@ function cloneForStorage(st) {
 }
 
 export function save(ctx) {
-  if (!ctx || ctx.mode !== "town") return;
+  if (!ctx) return;
+  // Sandbox sessions are ephemeral; never persist town state while sandboxing.
+  if (ctx.isSandbox) return;
+  if (ctx.mode !== "town") return;
   // Use the world entry tile as the key (where we will return in overworld)
   const wx = (ctx.worldReturnPos && typeof ctx.worldReturnPos.x === "number") ? (ctx.worldReturnPos.x | 0) : null;
   const wy = (ctx.worldReturnPos && typeof ctx.worldReturnPos.y === "number") ? (ctx.worldReturnPos.y | 0) : null;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/god.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/god.js
@@ -382,6 +382,21 @@ export function spawnEnemyById(ctx, id, count = 1) {
         ? override.damageScale
         : (typeof td.damageScale === "number" ? td.damageScale : 1.0);
 
+      // Log override usage in sandbox to make behavior visible during tuning.
+      try {
+        if (ctx.mode === "sandbox") {
+          const hasOverride = !!override;
+          const baseLine = `depth=${depthForStats}, baseHp=${baseHp}, baseAtk=${baseAtk}, baseXp=${baseXp}`;
+          const effLine = `hp=${hp}, atk=${atk}, xp=${xp}, dmgScale=${damageScale}`;
+          ctx.log(
+            hasOverride
+              ? `Sandbox: Spawning '${typeId}' with override (${baseLine}) → (${effLine}).`
+              : `Sandbox: Spawning '${typeId}' with base definition (${effLine}) at ${baseLine}.`,
+            "info"
+          );
+        }
+      } catch (_) {}
+
       ee = {
         x: spot.x,
         y: spot.y,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/god.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/god.js
@@ -800,6 +800,7 @@ attachGlobal("God", {
   spawnStairsHere,
   spawnItems,
   spawnEnemyNearby,
+  spawnEnemyById,
   setAlwaysCrit,
   toggleInvincible,
   setCritPart,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/god.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/god.js
@@ -74,9 +74,9 @@ export function spawnItems(ctx, count = 3) {
 }
 
 export function spawnEnemyNearby(ctx, count = 1) {
-  // Enemy spawning is supported in dungeon mode only
-  if (ctx.mode !== "dungeon") {
-    ctx.log("GOD: Enemy spawn works in dungeon mode only.", "warn");
+  // Enemy spawning is supported in dungeon or sandbox mode only
+  if (ctx.mode !== "dungeon" && ctx.mode !== "sandbox") {
+    ctx.log("GOD: Enemy spawn works in dungeon or sandbox mode only.", "warn");
     return;
   }
 
@@ -164,15 +164,6 @@ export function spawnEnemyNearby(ctx, count = 1) {
     return best;
   };
 
-  function linearAt(arr, depth, fallback = 1) {
-    if (!Array.isArray(arr) || arr.length === 0) return fallback;
-    let chosen = arr[0];
-    for (const e of arr) { if ((e[0] | 0) <= depth) chosen = e; }
-    const minD = chosen[0] | 0, baseV = Number(chosen[1] || fallback), slope = Number(chosen[2] || 0);
-    const delta = Math.max(0, depth - minD);
-    return Math.max(1, Math.floor(baseV + slope * delta));
-  }
-
   const spawned = [];
   // Abort if no registered enemy types
   if (!Array.isArray(window.GOD_SPAWN_CYCLE.list) || window.GOD_SPAWN_CYCLE.list.length === 0) {
@@ -246,6 +237,136 @@ export function spawnEnemyNearby(ctx, count = 1) {
   } else {
     ctx.log("GOD: No free space to spawn an enemy nearby.", "warn");
   }
+}
+
+/**
+ * Spawn a specific enemy type id near the player (dungeon or sandbox mode only).
+ * This uses the same placement logic as spawnEnemyNearby but does not cycle ids.
+ */
+export function spawnEnemyById(ctx, id, count = 1) {
+  const typeId = String(id || "").trim();
+  if (!typeId) {
+    ctx.log("GOD: Enemy id is empty; cannot spawn.", "warn");
+    return false;
+  }
+  // Enemy spawning is supported in dungeon or sandbox mode only
+  if (ctx.mode !== "dungeon" && ctx.mode !== "sandbox") {
+    ctx.log("GOD: spawnEnemyById works in dungeon or sandbox mode only.", "warn");
+    return false;
+  }
+
+  const EM = (typeof window !== "undefined" ? window.Enemies : null);
+  if (!EM || typeof EM.getTypeDef !== "function") {
+    ctx.log("GOD: Enemies registry not available; cannot spawn by id.", "warn");
+    return false;
+  }
+  const td = EM.getTypeDef(typeId);
+  if (!td) {
+    ctx.log(`GOD: Enemy id '${typeId}' not found in registry.`, "warn");
+    return false;
+  }
+
+  const isFreeFloor = (x, y) => {
+    try {
+      if (!ctx.inBounds(x, y)) return false;
+      const walkable = (typeof ctx.isWalkable === "function") ? ctx.isWalkable(x, y) : (ctx.map[y][x] === ctx.TILES.FLOOR || ctx.map[y][x] === ctx.TILES.DOOR || ctx.map[y][x] === ctx.TILES.STAIRS);
+      if (!walkable) return false;
+      if (ctx.player.x === x && ctx.player.y === y) return false;
+      const occEnemy = (ctx.occupancy && typeof ctx.occupancy.hasEnemy === "function") ? ctx.occupancy.hasEnemy(x, y) : ctx.enemies.some(e => e && e.x === x && e.y === y);
+      if (occEnemy) return false;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  };
+
+  const pickNearby = () => {
+    const maxR = 5;
+    const px = ctx.player.x | 0;
+    const py = ctx.player.y | 0;
+
+    for (let r = 1; r <= maxR; r++) {
+      const candidates = [];
+      for (let dy = -r; dy <= r; dy++) {
+        for (let dx = -r; dx <= r; dx++) {
+          if (Math.abs(dx) + Math.abs(dy) !== r) continue;
+          const x = px + dx;
+          const y = py + dy;
+          if (isFreeFloor(x, y)) candidates.push({ x, y });
+        }
+      }
+      if (candidates.length) {
+        for (let i = candidates.length - 1; i > 0; i--) {
+          const j = Math.floor(ctx.rng() * (i + 1));
+          const tmp = candidates[i]; candidates[i] = candidates[j]; candidates[j] = tmp;
+        }
+        return candidates[0];
+      }
+    }
+
+    let best = null;
+    let bestD = Infinity;
+    const rows = ctx.map.length;
+    const cols = rows ? (ctx.map[0] ? ctx.map[0].length : 0) : 0;
+    for (let y = 0; y < rows; y++) {
+      for (let x = 0; x < cols; x++) {
+        if (!isFreeFloor(x, y)) continue;
+        const md = Math.abs(x - px) + Math.abs(y - py);
+        if (md < bestD) { bestD = md; best = { x, y }; }
+      }
+    }
+    return best;
+  };
+
+  const spawned = [];
+  const n = Math.max(1, Math.min(50, (Number(count) || 0) | 0));
+
+  for (let i = 0; i < n; i++) {
+    const spot = pickNearby();
+    if (!spot) break;
+
+    let ee = null;
+    try {
+      // Prefer enemyFactory when it can honor a specific id in the future;
+      // for now, build directly from Enemies registry.
+      if (typeof ctx.enemyFactory === "function" && false) {
+        ee = ctx.enemyFactory(spot.x, spot.y, ctx.floor);
+      }
+    } catch (_) {}
+
+    if (!ee) {
+      const level = (EM.levelFor && typeof EM.levelFor === "function") ? EM.levelFor(typeId, ctx.floor, ctx.rng) : ctx.floor;
+      ee = {
+        x: spot.x,
+        y: spot.y,
+        type: typeId,
+        glyph: td.glyph ? td.glyph : ((typeId && typeId.length) ? typeId.charAt(0) : "?"),
+        hp: td.hp(ctx.floor),
+        atk: td.atk(ctx.floor),
+        xp: td.xp(ctx.floor),
+        level,
+        announced: false,
+      };
+    }
+
+    ctx.enemies.push(ee);
+    spawned.push(ee);
+    const cap = (s) => s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+    ctx.log(`GOD: Spawned ${cap(ee.type || "enemy")} Lv ${ee.level || 1} at (${ee.x},${ee.y}).`, "notice");
+  }
+
+  if (spawned.length) {
+    try {
+      const SS = ctx.StateSync || getMod(ctx, "StateSync");
+      if (SS && typeof SS.applyAndRefresh === "function") {
+        SS.applyAndRefresh(ctx, {});
+      }
+    } catch (_) {}
+    return true;
+  }
+
+  ctx.log("GOD: No free space to spawn an enemy nearby.", "warn");
+  return false;
 }
 
 export function setAlwaysCrit(ctx, enabled) {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/dungeon/dungeon_state.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/dungeon/dungeon_state.js
@@ -108,6 +108,8 @@ function cloneForStorage(st) {
 
 export function save(ctx) {
   if (!ctx) return;
+  // Sandbox sessions are ephemeral; never persist dungeon state while sandboxing.
+  if (ctx.isSandbox) return;
   if (ctx.mode !== "dungeon" || !ctx.dungeonInfo || !ctx.dungeonExitAt) return;
   const k = key(ctx.dungeonInfo.x, ctx.dungeonInfo.y);
   if (!ctx._dungeonStates) ctx._dungeonStates = Object.create(null);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
@@ -57,7 +57,8 @@ function getEnemyDefWithOverrides(ctx, type) {
  * Returns a plain item object: { kind: "potion", name, heal, count:1 }
  */
 function pickPotion(ctx, source) {
-  const def = getEnemyDefWithOverrides(ctx, source?.type || "");
+  const srcType = source && source.type ? source.type : "";
+  const def = getEnemyDefWithOverrides(ctx, srcType);
   const potW = def && def.lootPools && def.lootPools.potions ? def.lootPools.potions : null;
   if (!potW) return null;
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
@@ -22,33 +22,15 @@
 import { getMod, getGameData, getRNGUtils, getUIOrchestration } from "../utils/access.js";
 
 /**
- * Resolve an enemy definition, applying sandbox-only overrides (lootPools) when in sandbox mode.
+ * Resolve an enemy definition.
+ * Advanced sandbox-only loot pool overrides are currently disabled, so this
+ * always returns the base enemy definition from the registry.
  */
 function getEnemyDefWithOverrides(ctx, type) {
   const EM = getMod(ctx, "Enemies");
   const base = EM && typeof EM.getDefById === "function" ? EM.getDefById(type || "") : null;
   if (!base) return null;
-  if (!ctx || ctx.mode !== "sandbox") return base;
-  const overrides = ctx.sandboxEnemyOverrides && ctx.sandboxEnemyOverrides[type];
-  if (!overrides || !overrides.lootPools) return base;
-
-  const basePools = base.lootPools || null;
-  const oPools = overrides.lootPools || {};
-  // Clone base pools so we don't mutate shared registry
-  const mergedPools = basePools ? { ...basePools } : {};
-  for (const key of Object.keys(oPools)) {
-    const v = oPools[key];
-    if (v === null) {
-      // Explicitly disable this pool
-      delete mergedPools[key];
-    } else if (v && typeof v === "object") {
-      // Future extension: allow full weight overrides
-      mergedPools[key] = v;
-    }
-  }
-  const merged = Object.create(base);
-  merged.lootPools = mergedPools;
-  return merged;
+  return base;
 }
 
 /**

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
@@ -250,7 +250,8 @@ function pickEnemyBiasedEquipment(ctx, enemyType, tier) {
  * Returns: Array of items (gold/potion/equip/...)
  */
 export function generate(ctx, source) {
-  const type = (source && source.type) ? String(source.type).toLowerCase() : "goblin";
+  const rawType = (source && source.type) ? String(source.type) : "goblin";
+  const type = rawType.toLowerCase();
 
   // Helper: material registry lookup for pretty names
   function materialNameFor(id) {
@@ -364,7 +365,7 @@ export function generate(ctx, source) {
 
   // Potion drop: only when enemy has embedded potions weights in its lootPools
   (function maybeDropPotion() {
-    const def = getEnemyDefWithOverrides(ctx, type);
+    const def = getEnemyDefWithOverrides(ctx, rawType);
     const hasPotionsInPool = !!(def && def.lootPools && def.lootPools.potions);
     if (!hasPotionsInPool) return;
     const dropChance = 0.50;
@@ -375,13 +376,13 @@ export function generate(ctx, source) {
   })();
 
   const EM = getMod(ctx, "Enemies");
-  let tier = (EM && typeof EM.equipTierFor === "function") ? EM.equipTierFor(type) : (type === "ogre" ? 3 : (type === "troll" ? 2 : 1));
-  const equipChance = (EM && typeof EM.equipChanceFor === "function") ? EM.equipChanceFor(type) : (type === "ogre" ? 0.75 : (type === "troll" ? 0.55 : 0.35));
+  let tier = (EM && typeof EM.equipTierFor === "function") ? EM.equipTierFor(rawType) : (type === "ogre" ? 3 : (type === "troll" ? 2 : 1));
+  const equipChance = (EM && typeof EM.equipChanceFor === "function") ? EM.equipChanceFor(rawType) : (type === "ogre" ? 0.75 : (type === "troll" ? 0.55 : 0.35));
 
-  // Sandbox-only loot tier override: ctx.sandboxEnemyOverrides[type].equipTierOverride
+  // Sandbox-only loot tier override: ctx.sandboxEnemyOverrides[typeId].equipTierOverride
   try {
     if (ctx && ctx.mode === "sandbox" && ctx.sandboxEnemyOverrides && typeof ctx.sandboxEnemyOverrides === "object") {
-      const key = String(type || "");
+      const key = String(rawType || "");
       const lower = key.toLowerCase();
       const ov = ctx.sandboxEnemyOverrides[key] || ctx.sandboxEnemyOverrides[lower] || null;
       if (ov && typeof ov.equipTierOverride === "number") {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/index.html
@@ -129,6 +129,7 @@
       <button id="god-spawn-enemy-btn" class="btn">Spawn Enemy Nearby</button>
       <button id="god-spawn-stairs-btn" class="btn">Spawn Stairs Here</button>
       <button id="god-hire-follower-btn" class="btn" title="Hire a follower from followers.json (ignores normal acquisition flow)">Hire Follower (GOD)</button>
+      <button id="god-enter-sandbox-btn" class="btn" title="Enter a small sandbox dungeon room (no save persistence)">Enter Sandbox (Dungeon Room)</button>
       <button id="god-newgame-btn" class="btn" title="Start New Game">Start New Game</button>
     </div>
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/src/main.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/src/main.js
@@ -25,6 +25,7 @@ import '/world/fov.js';
 import '/data/loader.js';
 import '/data/flavor.js';
 import '/data/god.js';
+import '/core/god/controls.js';
 import '/data/tile_lookup.js';
 
 // Entities and dungeon adapters

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/god_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/god_panel.js
@@ -271,6 +271,16 @@ export function init(UI) {
     if (typeof UI.handlers.onRestart === "function") UI.handlers.onRestart();
   });
 
+  const sandboxBtn = byId("god-enter-sandbox-btn");
+  if (sandboxBtn) {
+    sandboxBtn.addEventListener("click", () => {
+      try { hide(); } catch (_) {}
+      if (typeof UI.handlers.onGodEnterSandbox === "function") {
+        UI.handlers.onGodEnterSandbox();
+      }
+    });
+  }
+
   // Smoke Config open
   const smokeBtn = byId("god-run-smoke-btn");
   smokeBtn?.addEventListener("click", () => {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/hud.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/hud.js
@@ -27,16 +27,6 @@ export function update(player, floor, time, perf, perfOn, weather) {
   // HP + statuses
   if (hpEl && player) {
     const parts = [`HP: ${Number(player.hp || 0).toFixed(1)}/${Number(player.maxHp || 0).toFixed(1)}`];
-    try {
-      const GA = (typeof window !== "undefined" && window.GameAPI) ? window.GameAPI : null;
-      const inv = GA && typeof GA.getInvincibleState === "function" ? !!GA.getInvincibleState() : false;
-      const sb = GA && typeof GA.getCtx === "function" ? GA.getCtx() : null;
-      const sandboxLabel = sb && sb.isSandbox ? " [SANDBOX]" : "";
-      const invLabel = inv ? " [INVINCIBLE]" : "";
-      if (sandboxLabel || invLabel) {
-        parts[0] += `${sandboxLabel}${invLabel}`;
-      }
-    } catch (_) {}
     const statuses = [];
     try {
       if (player.bleedTurns && player.bleedTurns > 0) statuses.push(`Bleeding (${player.bleedTurns})`);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/hud.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/hud.js
@@ -27,6 +27,16 @@ export function update(player, floor, time, perf, perfOn, weather) {
   // HP + statuses
   if (hpEl && player) {
     const parts = [`HP: ${Number(player.hp || 0).toFixed(1)}/${Number(player.maxHp || 0).toFixed(1)}`];
+    try {
+      const GA = (typeof window !== "undefined" && window.GameAPI) ? window.GameAPI : null;
+      const inv = GA && typeof GA.getInvincibleState === "function" ? !!GA.getInvincibleState() : false;
+      const sb = GA && typeof GA.getCtx === "function" ? GA.getCtx() : null;
+      const sandboxLabel = sb && sb.isSandbox ? " [SANDBOX]" : "";
+      const invLabel = inv ? " [INVINCIBLE]" : "";
+      if (sandboxLabel || invLabel) {
+        parts[0] += `${sandboxLabel}${invLabel}`;
+      }
+    } catch (_) {}
     const statuses = [];
     try {
       if (player.bleedTurns && player.bleedTurns > 0) statuses.push(`Bleeding (${player.bleedTurns})`);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -57,8 +57,56 @@ function getAnimalDefById(id) {
       if (!row || !row.id) continue;
       if (String(row.id).toLowerCase() === want) return row;
     }
-  } catch (_) </old_code><new_code>function isAnimalId(id) {
+  } catch (_) {}
+  return null;
+}
+
+function isAnimalId(id) {
   return !!getAnimalDefById(id);
+}
+
+function classifyEntityId(id) {
+  const v = String(id || "").trim();
+  if (!v) return "none";
+  try {
+    const EM = (typeof window !== "undefined" ? window.Enemies : null);
+    if (EM && typeof EM.getDefById === "function" && EM.getDefById(v)) {
+      return "enemy";
+    }
+  } catch (_) {}
+  if (isAnimalId(v)) return "animal";
+  return "custom";
+}
+
+function updateEntityStatusLabel() {
+  try {
+    const line = byId("sandbox-entity-status-line");
+    const txt = byId("sandbox-entity-status-text");
+    if (!line || !txt) return;
+    const id = currentEnemyId();
+    const kind = classifyEntityId(id);
+    let label = "(no id)";
+    let color = "#9ca3af";
+
+    if (!id) {
+      label = "(no id)";
+    } else if (kind === "enemy") {
+      label = "enemy (enemies.json)";
+      color = "#a5b4fc";
+    } else if (kind === "animal") {
+      label = "animal (animals.json)";
+      color = "#6ee7b7";
+    } else if (kind === "custom") {
+      label = "custom sandbox-only (not in enemies.json)";
+      color = "#fbbf24";
+    } else {
+      label = "unknown";
+      color = "#fca5a5";
+    }
+
+    txt.textContent = label;
+    line.style.color = color;
+  } catch (_) {}
 }
 
 function loadEnemyTypes() {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -645,6 +645,8 @@ export function init(UI) {
         if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
           window.GameAPI.log(`Sandbox: Applied enemy override for '${enemyId}' (depth ${depth}).`, "notice");
         }
+        // Refresh Advanced JSON view so the override is immediately visible when expanded.
+        try { refreshAdvancedJson(); } catch (_) {}
       } catch (_) {}
     });
   }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1345,6 +1345,7 @@ export function init(UI) {
         if (xpInput && xpInput.value !== "") next.xpAtDepth = Number(xpInput.value) || 0;
         if (dmgInput && dmgInput.value !== "") next.damageScale = Number(dmgInput.value) || 1;
         if (eqInput && eqInput.value !== "") next.equipChance = Number(eqInput.value) || 0;
+        const tierInput = byId("sandbox-equip-tier");
         if (tierInput && tierInput.value !== "") {
           const tRaw = (Number(tierInput.value) || 0) | 0;
           if (tRaw >= 1 && tRaw <= 3) next.equipTierOverride = tRaw;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -324,7 +324,8 @@ function ensurePanel() {
   el.id = "sandbox-panel";
   el.style.position = "fixed";
   el.style.top = "16px";
-  el.style.right = "16px";
+  // Push further to the right and constrain width so all sections fit without overflowing too far
+  el.style.right = "24px";
   el.style.zIndex = "31000";
   el.style.padding = "10px 12px";
   el.style.borderRadius = "8px";
@@ -334,8 +335,10 @@ function ensurePanel() {
   el.style.fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   el.style.fontSize = "13px";
   el.style.color = "#e5e7eb";
-  el.style.minWidth = "260px";
-  el.style.maxWidth = "320px";
+  el.style.minWidth = "280px";
+  el.style.maxWidth = "360px";
+  el.style.maxHeight = "80vh";
+  el.style.overflowY = "auto";
 
   el.innerHTML = `
     <div style="font-weight:600; letter-spacing:0.03em; text-transform:uppercase; font-size:11px; color:#a5b4fc; margin-bottom:6px;">
@@ -1181,6 +1184,24 @@ export function isOpen() {
   const el = byId("sandbox-panel");
   return !!(el && !el.hidden);
 }
+
+// Allow ESC to close the sandbox panel when it is open.
+(function installEscapeHandler() {
+  try {
+    if (typeof window === "undefined" || typeof document === "undefined") return;
+    document.addEventListener("keydown", (ev) => {
+      try {
+        if (ev.key === "Escape" || ev.key === "Esc") {
+          const el = byId("sandbox-panel");
+          if (el && !el.hidden) {
+            el.hidden = true;
+            ev.stopPropagation();
+          }
+        }
+      } catch (_) {}
+    });
+  } catch (_) {}
+})();
 
 import { attachGlobal } from "/utils/global.js";
 attachGlobal("SandboxPanel", { init, show, hide, isOpen });

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -514,8 +514,12 @@ function spawnWithCount(requestedCount) {
 
     // Animal path: spawn neutral wildlife by id when selected entity comes from animals.json.
     if (ctx && isAnimalId(enemyId)) {
-      spawned = trySpawnAnimalById(ctx, enemyId, n);
-      if (spawned) return;
+      const ok = trySpawnAnimalById(ctx, enemyId, n);
+      if (!ok && typeof window.GameAPI.log === "function") {
+        window.GameAPI.log(`Sandbox: Failed to spawn animal '${enemyId}'.`, "warn");
+      }
+      // Do not fall back to enemy spawning for animal ids.
+      return;
     }
 
     // Preferred path: call God.spawnEnemyById directly with live ctx when available.
@@ -617,12 +621,6 @@ function ensurePanel() {
                 placeholder="goblin, troll, bandit, deer, fox, boar..."
                 title="Type or edit the entity id to test. Must exist in enemies.json or animals.json to auto-populate."
                 style="flex:1; padding:3px 6px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
-              <button id="sandbox-enemy-prev-btn" type="button"
-                title="Select previous entity id from the combined enemies + animals registry."
-                style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">◀</button>
-              <button id="sandbox-enemy-next-btn" type="button"
-                title="Select next entity id from the combined enemies + animals registry."
-                style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">▶</button>
             </div>
             <div style="display:flex; align-items:center; gap:4px;">
               <span style="font-size:11px; color:#9ca3af; width:48px;"
@@ -954,31 +952,6 @@ export function init(UI) {
   }
 
   // Enemy cycling
-  const prevBtn = byId("sandbox-enemy-prev-btn");
-  const nextBtn = byId("sandbox-enemy-next-btn");
-  if (prevBtn) {
-    prevBtn.addEventListener("click", () => {
-      if (!_enemyTypes.length) {
-        loadEnemyTypes();
-      }
-      if (!_enemyTypes.length) return;
-      _enemyIndex = (_enemyTypes.length + _enemyIndex - 1) % _enemyTypes.length;
-      setEnemyId(_enemyTypes[_enemyIndex]);
-      syncBasicFormFromData();
-    });
-  }
-  if (nextBtn) {
-    nextBtn.addEventListener("click", () => {
-      if (!_enemyTypes.length) {
-        loadEnemyTypes();
-      }
-      if (!_enemyTypes.length) return;
-      _enemyIndex = (_enemyTypes.length + _enemyIndex + 1) % _enemyTypes.length;
-      setEnemyId(_enemyTypes[_enemyIndex]);
-      syncBasicFormFromData();
-    });
-  }
-
   // Enemy id manual input => refresh tuning fields when changed
   const enemyInput = byId("sandbox-enemy-id");
   if (enemyInput) enemyInput.addEventListener("change", () => {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1014,7 +1014,6 @@ export function init(UI) {
       syncBasicFormFromData();
     });
   }
-  }
 
   // Primary button visuals (Apply / Reset / Copy JSON)
   const applyBtn = byId("sandbox-apply-override-btn");

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -309,93 +309,142 @@ function ensurePanel() {
 
       <!-- Basic enemy tuning & spawn -->
       <div style="margin-top:6px; padding-top:4px; border-top:1px solid #374151;">
-        <div style="font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:#9ca3af; margin-bottom:4px;">
+        <div style="font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:#9ca3af; margin-bottom:4px;"
+          title="Most-used knobs for sandbox enemy testing: selection, depth, stats, spawn count, and overrides.">
           Basic / Default
         </div>
         <div style="display:flex; flex-direction:column; gap:4px;">
           <!-- Selection -->
           <div style="display:flex; align-items:center; gap:4px;">
-            <span style="font-size:11px; color:#9ca3af;">Enemy</span>
+            <span style="font-size:11px; color:#9ca3af;"
+              title="Base enemy id from data/entities/enemies.json (e.g. goblin, troll, bandit).">
+              Enemy
+            </span>
             <input id="sandbox-enemy-id" type="text"
               placeholder="goblin, troll, bandit..."
+              title="Type or edit the enemy id to test. Must exist in data/entities/enemies.json."
               style="flex:1; padding:3px 6px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             <button id="sandbox-enemy-prev-btn" type="button"
+              title="Select previous enemy id from the registry."
               style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">◀</button>
             <button id="sandbox-enemy-next-btn" type="button"
+              title="Select next enemy id from the registry."
               style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">▶</button>
           </div>
 
           <!-- Test depth -->
           <div style="display:flex; align-items:center; gap:6px;">
-            <span style="font-size:11px; color:#9ca3af;">Test depth</span>
+            <span style="font-size:11px; color:#9ca3af;"
+              title="Depth (floor) used to compute HP/ATK/XP from this enemy’s curves for sandbox tests. Does not change actual dungeon depth.">
+              Test depth
+            </span>
             <input id="sandbox-test-depth" type="number" min="1" max="20" value="3"
+              title="Depth used when resolving this enemy’s HP/ATK/XP curves during sandbox spawns."
               style="width:60px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
           </div>
 
           <!-- Visual / identity -->
           <div style="display:flex; flex-wrap:wrap; gap:4px;">
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 40px;">
-              <span style="font-size:11px; color:#9ca3af;">Glyph</span>
+              <span style="font-size:11px; color:#9ca3af;"
+                title="Single-character glyph drawn for this enemy in dungeon/sandbox view.">
+                Glyph
+              </span>
               <input id="sandbox-glyph" type="text" maxlength="1"
+                title="Glyph character shown on the map for this enemy in dungeon/sandbox."
                 style="width:34px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px; text-align:center;" />
             </div>
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">
-              <span style="font-size:11px; color:#9ca3af;">Color</span>
+              <span style="font-size:11px; color:#9ca3af;"
+                title="CSS color used for this enemy’s glyph (overrides enemies.json in sandbox only).">
+                Color
+              </span>
               <input id="sandbox-color" type="text"
                 placeholder="#8bd5a0"
+                title="Hex or CSS color string used to draw the enemy glyph in dungeon/sandbox."
                 style="flex:1; min-width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             </div>
           </div>
           <div style="display:flex; align-items:center; gap:4px;">
-            <span style="font-size:11px; color:#9ca3af;">Faction</span>
+            <span style="font-size:11px; color:#9ca3af;"
+              title="Faction id used by AI/encounters (e.g. monster, bandit, guard). Sandbox override only.">
+              Faction
+            </span>
             <input id="sandbox-faction" type="text"
               placeholder="monster, bandit..."
+              title="Faction string for this enemy in sandbox (controls which side it fights for)."
               style="flex:1; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
           </div>
 
           <!-- Core combat knobs -->
           <div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:2px;">
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">
-              <span style="font-size:11px; color:#9ca3af;">HP @ depth</span>
+              <span style="font-size:11px; color:#9ca3af;"
+                title="Hit points this enemy will have at the Test depth (sandbox-only override).">
+                HP @ depth
+              </span>
               <input id="sandbox-hp" type="number" min="1"
+                title="HP for this enemy at the chosen Test depth. Overrides the curve in sandbox."
                 style="width:64px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             </div>
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">
-              <span style="font-size:11px; color:#9ca3af;">ATK @ depth</span>
+              <span style="font-size:11px; color:#9ca3af;"
+                title="Attack stat this enemy will have at the Test depth (sandbox-only override).">
+                ATK @ depth
+              </span>
               <input id="sandbox-atk" type="number" min="0"
+                title="Attack value for this enemy at the chosen Test depth in sandbox."
                 style="width:64px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             </div>
           </div>
           <div style="display:flex; align-items:center; gap:4px;">
-            <span style="font-size:11px; color:#9ca3af;">XP @ depth</span>
+            <span style="font-size:11px; color:#9ca3af;"
+              title="Experience the player gains for killing this enemy at the Test depth (sandbox override).">
+              XP @ depth
+            </span>
             <input id="sandbox-xp" type="number" min="0"
+              title="XP reward used for this enemy at the chosen Test depth in sandbox."
               style="width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
           </div>
 
           <div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:2px;">
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 90px;">
-              <span style="font-size:11px; color:#9ca3af;">Damage scale</span>
+              <span style="font-size:11px; color:#9ca3af;"
+                title="Global multiplier on this enemy’s outgoing damage in sandbox.">
+                Damage scale
+              </span>
               <input id="sandbox-damage-scale" type="number" step="0.1"
+                title="Scale factor applied to this enemy’s damage output in sandbox (1.0 = base)."
                 style="width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             </div>
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 90px;">
-              <span style="font-size:11px; color:#9ca3af;">Equip chance</span>
+              <span style="font-size:11px; color:#9ca3af;"
+                title="Chance [0–1] this enemy carries or drops equipment (when loot tables support it).">
+                Equip chance
+              </span>
               <input id="sandbox-equip-chance" type="number" step="0.05" min="0" max="1"
+                title="Probability that this enemy has equipment in sandbox (0 = never, 1 = always)."
                 style="width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             </div>
           </div>
 
           <!-- Spawn + override controls -->
           <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
-            <span style="font-size:11px; color:#9ca3af;">Count</span>
+            <span style="font-size:11px; color:#9ca3af;"
+              title="How many copies of this enemy to spawn with each Spawn N click.">
+              Count
+            </span>
             <input id="sandbox-enemy-count" type="number" min="1" max="50" value="1"
+              title="Number of enemies to spawn when using Spawn N (sandbox only)."
               style="width:52px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
             <button id="sandbox-spawn1-btn" type="button"
+              title="Spawn exactly one enemy using the current sandbox override and Test depth."
               style="flex:1; padding:4px 6px; border-radius:6px; border:1px solid #22c55e;
                      background:#16a34a; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
               Spawn 1
             </button>
             <button id="sandbox-spawnn-btn" type="button"
+              title="Spawn Count enemies using the current sandbox override and Test depth."
               style="flex:1; padding:4px 6px; border-radius:6px; border:1px solid #22c55e;
                      background:#15803d; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
               Spawn N
@@ -404,11 +453,13 @@ function ensurePanel() {
 
           <div style="display:flex; gap:6px; margin-top:4px;">
             <button id="sandbox-apply-override-btn" type="button"
+              title="Save the Basic fields as a sandbox-only override for this enemy (affects future spawns in this session)."
               style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
                      background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
               Apply as Override
             </button>
             <button id="sandbox-reset-override-btn" type="button"
+              title="Remove the sandbox override for this enemy and fall back to its base JSON definition."
               style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
                      background:#020617; color:#9ca3af; font-size:12px; cursor:pointer; text-align:center;">
               Reset to Base
@@ -420,26 +471,37 @@ function ensurePanel() {
       <!-- Advanced JSON overrides -->
       <div style="margin-top:6px; padding-top:4px; border-top:1px solid #374151;">
         <button id="sandbox-advanced-toggle-btn" type="button"
+          title="Show expert JSON view/edit for this enemy’s sandbox override (advanced use only)."
           style="width:100%; padding:4px 8px; border-radius:6px; border:1px solid #4b5563;
                  background:#020617; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:left;">
           Advanced ▸
         </button>
         <div id="sandbox-advanced-body" style="display:none; margin-top:4px; display:flex; flex-direction:column; gap:4px;">
-          <div style="font-size:11px; color:#9ca3af;">Base JSON (read-only)</div>
+          <div style="font-size:11px; color:#9ca3af;"
+            title="Read-only copy of this enemy’s definition from data/entities/enemies.json.">
+            Base JSON (read-only)
+          </div>
           <textarea id="sandbox-advanced-base-json" readonly
+            title="Enemy row as loaded from data/entities/enemies.json (cannot be edited here)."
             style="width:100%; min-height:80px; max-height:120px; padding:4px 6px; border-radius:4px;
                    border:1px solid #4b5563; background:#020617; color:#9ca3af; font-size:11px; font-family:'JetBrains Mono',monospace;"></textarea>
-          <div style="font-size:11px; color:#9ca3af;">Override JSON (sandbox-only)</div>
+          <div style="font-size:11px; color:#9ca3af;"
+            title="Sandbox-only override object that is merged on top of the base definition.">
+            Override JSON (sandbox-only)
+          </div>
           <textarea id="sandbox-advanced-override-json"
+            title="Edit sandbox override as raw JSON for this enemy, then click Apply JSON to use it."
             style="width:100%; min-height:80px; max-height:140px; padding:4px 6px; border-radius:4px;
                    border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:11px; font-family:'JetBrains Mono',monospace;"></textarea>
           <div style="display:flex; gap:6px; margin-top:2px;">
             <button id="sandbox-advanced-apply-json-btn" type="button"
+              title="Parse Override JSON and store it as the sandbox override for this enemy."
               style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
                      background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
               Apply JSON
             </button>
             <button id="sandbox-advanced-reset-json-btn" type="button"
+              title="Clear JSON override for this enemy (equivalent to Reset to Base in Basic section)."
               style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
                      background:#020617; color:#9ca3af; font-size:12px; cursor:pointer; text-align:center;">
               Reset Override

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -544,7 +544,7 @@ function trySpawnAnimalById(ctx, id, count) {
 
     if (spawned.length) {
       try {
-        const SS = ctx.StateSync;
+        const SS = ctx.StateSync || getMod(ctx, "StateSync");
         if (SS && typeof SS.applyAndRefresh === "function") {
           SS.applyAndRefresh(ctx, {});
         }
@@ -706,7 +706,7 @@ function spawnCustomSandboxEnemy(ctx, id, count) {
 
     if (spawned.length) {
       try {
-        const SS = ctx.StateSync;
+        const SS = ctx.StateSync || getMod(ctx, "StateSync");
         if (SS && typeof SS.applyAndRefresh === "function") {
           SS.applyAndRefresh(ctx, {});
         }
@@ -1704,5 +1704,6 @@ export function isOpen() {
   } catch (_) {}
 })();
 
+import { getMod } from "/utils/access.js";
 import { attachGlobal } from "/utils/global.js";
 attachGlobal("SandboxPanel", { init, show, hide, isOpen });

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -335,10 +335,12 @@ function ensurePanel() {
   el.style.fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   el.style.fontSize = "13px";
   el.style.color = "#e5e7eb";
-  el.style.minWidth = "280px";
-  el.style.maxWidth = "360px";
+  // Slightly wider to comfortably fit all rows and labels
+  el.style.minWidth = "320px";
+  el.style.maxWidth = "420px";
   el.style.maxHeight = "80vh";
   el.style.overflowY = "auto";
+;
 
   el.innerHTML = `
     <div style="font-weight:600; letter-spacing:0.03em; text-transform:uppercase; font-size:11px; color:#a5b4fc; margin-bottom:6px;">
@@ -517,8 +519,8 @@ function ensurePanel() {
             </div>
 
             <!-- Equipment weights -->
-            <div style="display:flex; flex-wrap:wrap; gap:6px;">
-              <div style="flex:1 1 130px; min-width:130px;">
+            <div style="display:flex; flex-direction:column; gap:6px;">
+              <div style="flex:1 1 auto;">
                 <div style="font-size:11px; color:#9ca3af; margin-bottom:1px;">Weapons (weights)</div>
                 <div style="display:flex; flex-direction:column; gap:2px;">
                   <div style="display:flex; align-items:center; gap:4px;">
@@ -566,7 +568,7 @@ function ensurePanel() {
                 </div>
               </div>
 
-              <div style="flex:1 1 130px; min-width:130px;">
+              <div style="flex:1 1 auto;">
                 <div style="font-size:11px; color:#9ca3af; margin-bottom:1px;">Armor (weights)</div>
                 <div style="display:flex; flex-direction:column; gap:2px;">
                   <div style="display:flex; align-items:center; gap:4px;">

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -249,6 +249,18 @@ export function init(UI) {
   const panel = ensurePanel();
   void panel; // silence lints
 
+  // If we have enemy types and no current selection, preselect the first type.
+  try {
+    const enemyInput = byId("sandbox-enemy-id");
+    if (enemyInput && !_enemyTypes.length) {
+      loadEnemyTypes();
+    }
+    if (enemyInput && _enemyTypes.length && !enemyInput.value) {
+      _enemyIndex = 0;
+      setEnemyId(_enemyTypes[0]);
+    }
+  } catch (_) {}
+
   // AI toggle
   const aiBtn = byId("sandbox-ai-toggle-btn");
   if (aiBtn) {
@@ -276,6 +288,9 @@ export function init(UI) {
   const nextBtn = byId("sandbox-enemy-next-btn");
   if (prevBtn) {
     prevBtn.addEventListener("click", () => {
+      if (!_enemyTypes.length) {
+        loadEnemyTypes();
+      }
       if (!_enemyTypes.length) return;
       _enemyIndex = (_enemyIndex - 1 + _enemyTypes.length) % _enemyTypes.length;
       setEnemyId(_enemyTypes[_enemyIndex]);
@@ -284,6 +299,9 @@ export function init(UI) {
   }
   if (nextBtn) {
     nextBtn.addEventListener("click", () => {
+      if (!_enemyTypes.length) {
+        loadEnemyTypes();
+      }
       if (!_enemyTypes.length) return;
       _enemyIndex = (_enemyIndex + 1) % _enemyTypes.length;
       setEnemyId(_enemyTypes[_enemyIndex]);
@@ -409,6 +427,15 @@ export function init(UI) {
 export function show() {
   const el = ensurePanel();
   el.hidden = false;
+  // Ensure enemy types and default selection are available when the panel opens
+  try {
+    loadEnemyTypes();
+    const enemyInput = byId("sandbox-enemy-id");
+    if (enemyInput && _enemyTypes.length && !enemyInput.value) {
+      _enemyIndex = 0;
+      setEnemyId(_enemyTypes[0]);
+    }
+  } catch (_) {}
   // Refresh state when panel becomes visible
   refreshAiToggle();
   refreshAdvancedSection();

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1,5 +1,5 @@
 /**
- * SandboxPanel: minimal overlay for sandbox mode controls (F10).
+ * SandboxPanel: overlay for sandbox mode enemy testing (F10).
  *
  * Exports (ESM + window.SandboxPanel):
  * - init(UI)
@@ -8,14 +8,122 @@
  * - isOpen()
  *
  * Behavior:
- * - Only intended for ctx.isSandbox === true.
- * - F10 toggles this panel via UI.handlers.onToggleSandboxPanel.
- * - Provides an explicit "Exit Sandbox and Start New Game" button, which just
- *   invokes UI.handlers.onRestart() (same as existing GOD new game).
+ * - Only intended for sandbox mode (ctx.mode === "sandbox").
+ * - F10 toggles this panel via Input handlers wired in GameUIBridge.
+ * - Focuses purely on enemy testing:
+ *   - Enemy AI toggle (on/off)
+ *   - Basic spawn: choose enemy id + count, spawn near player
+ *   - Advanced: per-enemy loot pool toggles (weapons/armor/potions) for sandbox-only tests
+ *
+ * Generic GOD actions (heal, items, restart) remain in the GOD panel.
  */
 
 function byId(id) {
   try { return document.getElementById(id); } catch (_) { return null; }
+}
+
+let _ui = null;
+// Cached enemy ids for cycling via prev/next buttons
+let _enemyTypes = [];
+let _enemyIndex = 0;
+
+function loadEnemyTypes() {
+  try {
+    const EM = (typeof window !== "undefined" ? window.Enemies : null);
+    if (EM && typeof EM.listTypes === "function") {
+      const list = EM.listTypes() || [];
+      _enemyTypes = Array.isArray(list) ? list.slice(0) : [];
+      _enemyTypes.sort();
+    }
+  } catch (_) {
+    _enemyTypes = [];
+  }
+}
+
+function currentEnemyId() {
+  const input = byId("sandbox-enemy-id");
+  if (!input) return "";
+  return String(input.value || "").trim();
+}
+
+function setEnemyId(id) {
+  const input = byId("sandbox-enemy-id");
+  if (!input) return;
+  input.value = id || "";
+}
+
+/**
+ * Update the Enemy AI toggle button label from current ctx.sandboxFlags.
+ */
+function refreshAiToggle() {
+  try {
+    const btn = byId("sandbox-ai-toggle-btn");
+    if (!btn || !window.GameAPI || typeof window.GameAPI.getCtx !== "function") return;
+    const ctx = window.GameAPI.getCtx();
+    if (!ctx) return;
+    const flags = ctx.sandboxFlags || {};
+    const on = flags.aiEnabled !== false;
+    btn.textContent = on ? "Enemy AI: On" : "Enemy AI: Off";
+  } catch (_) {}
+}
+
+/**
+ * Update advanced section (loot pool toggles) based on enemy id and overrides.
+ */
+function refreshAdvancedSection() {
+  try {
+    if (!window.GameAPI || typeof window.GameAPI.getCtx !== "function") return;
+    const ctx = window.GameAPI.getCtx();
+    if (!ctx) return;
+    const enemyId = currentEnemyId();
+    const section = byId("sandbox-advanced-section");
+    if (!section) return;
+
+    if (!enemyId) {
+      section.style.opacity = "0.5";
+      section.style.pointerEvents = "none";
+      return;
+    }
+
+    const EM = (typeof window !== "undefined" ? window.Enemies : null);
+    const def = EM && typeof EM.getDefById === "function" ? EM.getDefById(enemyId) : null;
+    if (!def) {
+      section.style.opacity = "0.5";
+      section.style.pointerEvents = "none";
+      return;
+    }
+
+    section.style.opacity = "1.0";
+    section.style.pointerEvents = "auto";
+
+    const basePools = def.lootPools || {};
+    const overrides = ctx.sandboxEnemyOverrides && ctx.sandboxEnemyOverrides[enemyId];
+    const oPools = overrides && overrides.lootPools ? overrides.lootPools : {};
+
+    function poolEnabled(name) {
+      // If override says null for this pool, it's disabled; otherwise enabled when base has it.
+      if (!basePools || !basePools[name]) return false;
+      if (Object.prototype.hasOwnProperty.call(oPools, name) && oPools[name] === null) return false;
+      return true;
+    }
+
+    const weaponsCb = byId("sandbox-pool-weapons");
+    const armorCb = byId("sandbox-pool-armor");
+    const potionsCb = byId("sandbox-pool-potions");
+
+    if (weaponsCb) {
+      weaponsCb.disabled = !basePools.weapons;
+      weaponsCb.checked = basePools.weapons ? poolEnabled("weapons") : false;
+    }
+    if (armorCb) {
+      armorCb.disabled = !basePools.armor;
+      armorCb.checked = basePools.armor ? poolEnabled("armor") : false;
+    }
+    if (potionsCb) {
+      potionsCb.disabled = !basePools.potions;
+      potionsCb.checked = basePools.potions ? poolEnabled("potions") : false;
+    }
+  } catch (_) {}
 }
 
 function ensurePanel() {
@@ -36,25 +144,97 @@ function ensurePanel() {
   el.style.fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
   el.style.fontSize = "13px";
   el.style.color = "#e5e7eb";
-  el.style.minWidth = "220px";
-  el.style.maxWidth = "260px";
+  el.style.minWidth = "260px";
+  el.style.maxWidth = "320px";
 
   el.innerHTML = `
     <div style="font-weight:600; letter-spacing:0.03em; text-transform:uppercase; font-size:11px; color:#a5b4fc; margin-bottom:6px;">
       Sandbox Controls
     </div>
-    <div id="sandbox-panel-body" style="display:flex; flex-direction:column; gap:6px;">
+    <div id="sandbox-panel-body" style="display:flex; flex-direction:column; gap:8px;">
       <div id="sandbox-panel-mode-label" style="font-size:12px; color:#e5e7eb;">
         Mode: <span style="color:#fbbf24;">Sandbox Room</span>
       </div>
       <div style="font-size:11px; color:#9ca3af;">
         Press <span style="color:#e5e7eb;">F10</span> to toggle this panel.
       </div>
-      <button id="sandbox-exit-btn" type="button"
-        style="margin-top:4px; padding:5px 8px; border-radius:6px; border:1px solid #4b5563;
-               background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:left;">
-        Exit Sandbox and Start New Game
-      </button>
+
+      <!-- Behavior toggles -->
+      <div style="margin-top:4px; padding-top:4px; border-top:1px solid #374151;">
+        <div style="font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:#9ca3af; margin-bottom:4px;">
+          Behavior
+        </div>
+        <button id="sandbox-ai-toggle-btn" type="button"
+          style="padding:4px 8px; border-radius:6px; border:1px solid #4b5563;
+                 background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; width:100%; text-align:left;">
+          Enemy AI: On
+        </button>
+      </div>
+
+      <!-- Basic spawn -->
+      <div style="margin-top:6px; padding-top:4px; border-top:1px solid #374151;">
+        <div style="font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:#9ca3af; margin-bottom:4px;">
+          Basic Spawn
+        </div>
+        <div style="display:flex; flex-direction:column; gap:4px;">
+          <div style="display:flex; align-items:center; gap:4px;">
+            <span style="font-size:11px; color:#9ca3af;">Enemy</span>
+            <input id="sandbox-enemy-id" type="text"
+              placeholder="goblin, troll, bandit..."
+              style="flex:1; padding:3px 6px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            <button id="sandbox-enemy-prev-btn" type="button"
+              style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">◀</button>
+            <button id="sandbox-enemy-next-btn" type="button"
+              style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">▶</button>
+          </div>
+          <div style="display:flex; align-items:center; gap:6px;">
+            <span style="font-size:11px; color:#9ca3af;">Count</span>
+            <input id="sandbox-enemy-count" type="number" min="1" max="50" value="1"
+              style="width:52px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            <button id="sandbox-spawn-btn" type="button"
+              style="flex:1; padding:4px 8px; border-radius:6px; border:1px solid #22c55e;
+                     background:#16a34a; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
+              Spawn
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Advanced overrides (loot pools only for now) -->
+      <div id="sandbox-advanced-section" style="margin-top:6px; padding-top:4px; border-top:1px solid #374151;">
+        <div style="font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:#9ca3af; margin-bottom:4px;">
+          Advanced (Loot Pools)
+        </div>
+        <div style="font-size:11px; color:#9ca3af; margin-bottom:4px;">
+          Configure which embedded loot pools are active for the selected enemy when killed in sandbox.
+        </div>
+        <div style="display:flex; flex-direction:column; gap:2px; font-size:12px;">
+          <label style="display:flex; align-items:center; gap:6px;">
+            <input id="sandbox-pool-weapons" type="checkbox" checked />
+            <span>Weapons pool</span>
+          </label>
+          <label style="display:flex; align-items:center; gap:6px;">
+            <input id="sandbox-pool-armor" type="checkbox" checked />
+            <span>Armor pool</span>
+          </label>
+          <label style="display:flex; align-items:center; gap:6px;">
+            <input id="sandbox-pool-potions" type="checkbox" checked />
+            <span>Potions pool</span>
+          </label>
+        </div>
+        <div style="display:flex; gap:6px; margin-top:6px;">
+          <button id="sandbox-apply-override-btn" type="button"
+            style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
+                   background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
+            Apply Override
+          </button>
+          <button id="sandbox-reset-override-btn" type="button"
+            style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
+                   background:#020617; color:#9ca3af; font-size:12px; cursor:pointer; text-align:center;">
+            Reset to Base
+          </button>
+        </div>
+      </div>
     </div>
   `;
 
@@ -63,27 +243,175 @@ function ensurePanel() {
   return el;
 }
 
-let _ui = null;
-
 export function init(UI) {
   _ui = UI || null;
+  loadEnemyTypes();
   const panel = ensurePanel();
-  const exitBtn = byId("sandbox-exit-btn");
-  if (exitBtn) {
-    exitBtn.addEventListener("click", () => {
-      try { hide(); } catch (_) {}
+  void panel; // silence lints
+
+  // AI toggle
+  const aiBtn = byId("sandbox-ai-toggle-btn");
+  if (aiBtn) {
+    aiBtn.addEventListener("click", () => {
       try {
-        if (_ui && _ui.handlers && typeof _ui.handlers.onRestart === "function") {
-          _ui.handlers.onRestart();
+        if (!window.GameAPI || typeof window.GameAPI.getCtx !== "function") return;
+        const ctx = window.GameAPI.getCtx();
+        if (!ctx) return;
+        ctx.sandboxFlags = ctx.sandboxFlags || {};
+        const on = ctx.sandboxFlags.aiEnabled !== false;
+        ctx.sandboxFlags.aiEnabled = !on;
+        if (typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(
+            ctx.sandboxFlags.aiEnabled ? "Sandbox: Enemy AI enabled." : "Sandbox: Enemy AI disabled; enemies will not act.",
+            "notice"
+          );
+        }
+        refreshAiToggle();
+      } catch (_) {}
+    });
+  }
+
+  // Enemy cycling
+  const prevBtn = byId("sandbox-enemy-prev-btn");
+  const nextBtn = byId("sandbox-enemy-next-btn");
+  if (prevBtn) {
+    prevBtn.addEventListener("click", () => {
+      if (!_enemyTypes.length) return;
+      _enemyIndex = (_enemyIndex - 1 + _enemyTypes.length) % _enemyTypes.length;
+      setEnemyId(_enemyTypes[_enemyIndex]);
+      refreshAdvancedSection();
+    });
+  }
+  if (nextBtn) {
+    nextBtn.addEventListener("click", () => {
+      if (!_enemyTypes.length) return;
+      _enemyIndex = (_enemyIndex + 1) % _enemyTypes.length;
+      setEnemyId(_enemyTypes[_enemyIndex]);
+      refreshAdvancedSection();
+    });
+  }
+
+  // Enemy id manual input => refresh advanced panel on blur/change
+  const enemyInput = byId("sandbox-enemy-id");
+  if (enemyInput) {
+    enemyInput.addEventListener("change", () => {
+      refreshAdvancedSection();
+    });
+  }
+
+  // Spawn button
+  const spawnBtn = byId("sandbox-spawn-btn");
+  if (spawnBtn) {
+    spawnBtn.addEventListener("click", () => {
+      try {
+        if (!window.GameAPI) return;
+        const enemyId = currentEnemyId();
+        if (!enemyId) {
+          if (typeof window.GameAPI.log === "function") {
+            window.GameAPI.log("Sandbox: Enemy id is empty; cannot spawn.", "warn");
+          }
+          return;
+        }
+        const cntInput = byId("sandbox-enemy-count");
+        let n = 1;
+        if (cntInput) {
+          n = (Number(cntInput.value) || 1) | 0;
+        }
+        if (n < 1) n = 1;
+        if (n > 50) n = 50;
+
+        if (typeof window.GameAPI.spawnEnemyById === "function") {
+          window.GameAPI.spawnEnemyById(enemyId, n);
+        } else if (typeof window.GameAPI.spawnEnemyNearby === "function") {
+          // Fallback: random spawn when by-id helper is unavailable
+          window.GameAPI.spawnEnemyNearby(n);
+          if (typeof window.GameAPI.log === "function") {
+            window.GameAPI.log("Sandbox: spawnEnemyById not available; used random spawnEnemyNearby instead.", "warn");
+          }
         }
       } catch (_) {}
     });
   }
+
+  // Advanced overrides: apply/reset
+  const applyBtn = byId("sandbox-apply-override-btn");
+  if (applyBtn) {
+    applyBtn.addEventListener("click", () => {
+      try {
+        if (!window.GameAPI || typeof window.GameAPI.getCtx !== "function") return;
+        const ctx = window.GameAPI.getCtx();
+        if (!ctx) return;
+        const enemyId = currentEnemyId();
+        if (!enemyId) return;
+
+        const EM = (typeof window !== "undefined" ? window.Enemies : null);
+        const def = EM && typeof EM.getDefById === "function" ? EM.getDefById(enemyId) : null;
+        if (!def || !def.lootPools) return;
+
+        const basePools = def.lootPools || {};
+        const weaponsCb = byId("sandbox-pool-weapons");
+        const armorCb = byId("sandbox-pool-armor");
+        const potionsCb = byId("sandbox-pool-potions");
+
+        const overrides = ctx.sandboxEnemyOverrides || (ctx.sandboxEnemyOverrides = Object.create(null));
+        const poolsOverride = {};
+
+        function maybeSet(poolName, cb) {
+          if (!cb || cb.disabled || !basePools[poolName]) return;
+          if (!cb.checked) {
+            // Explicitly disable this pool
+            poolsOverride[poolName] = null;
+          }
+        }
+
+        maybeSet("weapons", weaponsCb);
+        maybeSet("armor", armorCb);
+        maybeSet("potions", potionsCb);
+
+        if (Object.keys(poolsOverride).length === 0) {
+          // No overrides needed; clear any existing one
+          delete overrides[enemyId];
+        } else {
+          overrides[enemyId] = { lootPools: poolsOverride };
+        }
+
+        if (typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(`Sandbox: Applied loot pool override for '${enemyId}'.`, "notice");
+        }
+        refreshAdvancedSection();
+      } catch (_) {}
+    });
+  }
+
+  const resetBtn = byId("sandbox-reset-override-btn");
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      try {
+        if (!window.GameAPI || typeof window.GameAPI.getCtx !== "function") return;
+        const ctx = window.GameAPI.getCtx();
+        if (!ctx) return;
+        const enemyId = currentEnemyId();
+        if (!enemyId || !ctx.sandboxEnemyOverrides) return;
+        delete ctx.sandboxEnemyOverrides[enemyId];
+        if (typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(`Sandbox: Cleared loot pool override for '${enemyId}'.`, "notice");
+        }
+        refreshAdvancedSection();
+      } catch (_) {}
+    });
+  }
+
+  // Initialize button labels/sections
+  refreshAiToggle();
+  refreshAdvancedSection();
 }
 
 export function show() {
   const el = ensurePanel();
   el.hidden = false;
+  // Refresh state when panel becomes visible
+  refreshAiToggle();
+  refreshAdvancedSection();
 }
 
 export function hide() {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1524,10 +1524,6 @@ export function init(UI) {
             }
           }
         } catch (_) {}
-             }
-            }
-          }
-        } catch (_) {}
         const blockBaseVal = baseRow && typeof baseRow.blockBase === "number" ? baseRow.blockBase : 0.06;
 
         let weightByDepthVal = null;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1,0 +1,100 @@
+/**
+ * SandboxPanel: minimal overlay for sandbox mode controls (F10).
+ *
+ * Exports (ESM + window.SandboxPanel):
+ * - init(UI)
+ * - show()
+ * - hide()
+ * - isOpen()
+ *
+ * Behavior:
+ * - Only intended for ctx.isSandbox === true.
+ * - F10 toggles this panel via UI.handlers.onToggleSandboxPanel.
+ * - Provides an explicit "Exit Sandbox and Start New Game" button, which just
+ *   invokes UI.handlers.onRestart() (same as existing GOD new game).
+ */
+
+function byId(id) {
+  try { return document.getElementById(id); } catch (_) { return null; }
+}
+
+function ensurePanel() {
+  let el = byId("sandbox-panel");
+  if (el) return el;
+
+  el = document.createElement("div");
+  el.id = "sandbox-panel";
+  el.style.position = "fixed";
+  el.style.top = "16px";
+  el.style.right = "16px";
+  el.style.zIndex = "31000";
+  el.style.padding = "10px 12px";
+  el.style.borderRadius = "8px";
+  el.style.border = "1px solid #1f2937";
+  el.style.background = "rgba(15,23,42,0.95)";
+  el.style.boxShadow = "0 20px 40px rgba(0,0,0,0.7)";
+  el.style.fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  el.style.fontSize = "13px";
+  el.style.color = "#e5e7eb";
+  el.style.minWidth = "220px";
+  el.style.maxWidth = "260px";
+
+  el.innerHTML = `
+    <div style="font-weight:600; letter-spacing:0.03em; text-transform:uppercase; font-size:11px; color:#a5b4fc; margin-bottom:6px;">
+      Sandbox Controls
+    </div>
+    <div id="sandbox-panel-body" style="display:flex; flex-direction:column; gap:6px;">
+      <div id="sandbox-panel-mode-label" style="font-size:12px; color:#e5e7eb;">
+        Mode: <span style="color:#fbbf24;">Sandbox Room</span>
+      </div>
+      <div style="font-size:11px; color:#9ca3af;">
+        Press <span style="color:#e5e7eb;">F10</span> to toggle this panel.
+      </div>
+      <button id="sandbox-exit-btn" type="button"
+        style="margin-top:4px; padding:5px 8px; border-radius:6px; border:1px solid #4b5563;
+               background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:left;">
+        Exit Sandbox and Start New Game
+      </button>
+    </div>
+  `;
+
+  document.body.appendChild(el);
+  el.hidden = true;
+  return el;
+}
+
+let _ui = null;
+
+export function init(UI) {
+  _ui = UI || null;
+  const panel = ensurePanel();
+  const exitBtn = byId("sandbox-exit-btn");
+  if (exitBtn) {
+    exitBtn.addEventListener("click", () => {
+      try { hide(); } catch (_) {}
+      try {
+        if (_ui && _ui.handlers && typeof _ui.handlers.onRestart === "function") {
+          _ui.handlers.onRestart();
+        }
+      } catch (_) {}
+    });
+  }
+}
+
+export function show() {
+  const el = ensurePanel();
+  el.hidden = false;
+}
+
+export function hide() {
+  const el = byId("sandbox-panel");
+  if (el) el.hidden = true;
+}
+
+export function isOpen() {
+  const el = byId("sandbox-panel");
+  return !!(el && !el.hidden);
+}
+
+import { attachGlobal } from "/utils/global.js";
+attachGlobal("SandboxPanel", { init, show, hide, isOpen });

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -67,7 +67,200 @@ function refreshAiToggle() {
   } catch (_) {}
 }
 
+/**
+ * Helper: get current ctx safely.
+ */
+function getCtxSafe() {
+  try {
+    if (!window.GameAPI || typeof window.GameAPI.getCtx !== "function") return null;
+    return window.GameAPI.getCtx() || null;
+  } catch (_) {
+    return null;
+  }
+}
 
+/**
+ * Sync basic fields (test depth, glyph/color/faction, HP/ATK/XP, damageScale, equipChance)
+ * from the base enemy definition and any sandbox override on ctx.
+ */
+function syncBasicFormFromData() {
+  try {
+    const enemyId = currentEnemyId();
+    if (!enemyId) return;
+    const ctx = getCtxSafe();
+    if (!ctx) return;
+
+    const EM = (typeof window !== "undefined" ? window.Enemies : null);
+    const def = EM && typeof EM.getDefById === "function" ? EM.getDefById(enemyId) : null;
+    if (!def) return;
+
+    const overridesRoot = ctx.sandboxEnemyOverrides && typeof ctx.sandboxEnemyOverrides === "object"
+      ? ctx.sandboxEnemyOverrides
+      : null;
+    const override = overridesRoot ? overridesRoot[enemyId] || null : null;
+
+    const depthInput = byId("sandbox-test-depth");
+    let depth = 3;
+    if (depthInput && depthInput.value) {
+      const v = (Number(depthInput.value) || 0) | 0;
+      if (v > 0) depth = v;
+    } else if (override && typeof override.testDepth === "number") {
+      depth = (override.testDepth | 0) || 3;
+    }
+    if (depthInput) depthInput.value = String(depth);
+
+    const hpBase = typeof def.hp === "function" ? def.hp(depth) : 0;
+    const atkBase = typeof def.atk === "function" ? def.atk(depth) : 0;
+    const xpBase = typeof def.xp === "function" ? def.xp(depth) : 0;
+
+    const glyphInput = byId("sandbox-glyph");
+    const colorInput = byId("sandbox-color");
+    const factionInput = byId("sandbox-faction");
+    const hpInput = byId("sandbox-hp");
+    const atkInput = byId("sandbox-atk");
+    const xpInput = byId("sandbox-xp");
+    const dmgInput = byId("sandbox-damage-scale");
+    const eqInput = byId("sandbox-equip-chance");
+
+    if (glyphInput) {
+      glyphInput.value = (override && typeof override.glyph === "string")
+        ? override.glyph
+        : (def.glyph || "");
+    }
+    if (colorInput) {
+      colorInput.value = (override && typeof override.color === "string")
+        ? override.color
+        : (def.color || "");
+    }
+    if (factionInput) {
+      factionInput.value = (override && typeof override.faction === "string")
+        ? override.faction
+        : (def.faction || "");
+    }
+    if (hpInput) {
+      hpInput.value = (override && typeof override.hpAtDepth === "number")
+        ? String(override.hpAtDepth)
+        : (hpBase ? String(hpBase) : "");
+    }
+    if (atkInput) {
+      atkInput.value = (override && typeof override.atkAtDepth === "number")
+        ? String(override.atkAtDepth)
+        : (atkBase ? String(atkBase) : "");
+    }
+    if (xpInput) {
+      xpInput.value = (override && typeof override.xpAtDepth === "number")
+        ? String(override.xpAtDepth)
+        : (xpBase ? String(xpBase) : "");
+    }
+
+    const baseDamageScale = (typeof def.damageScale === "number" ? def.damageScale : 1.0);
+    const baseEquipChance = (typeof def.equipChance === "number" ? def.equipChance : 0.35);
+
+    if (dmgInput) {
+      const val = (override && typeof override.damageScale === "number") ? override.damageScale : baseDamageScale;
+      dmgInput.value = String(val);
+    }
+    if (eqInput) {
+      const val = (override && typeof override.equipChance === "number") ? override.equipChance : baseEquipChance;
+      eqInput.value = String(val);
+    }
+  } catch (_) {}
+}
+
+/**
+ * Populate Advanced JSON view (base + override) for the current enemy.
+ */
+function refreshAdvancedJson() {
+  try {
+    const enemyId = currentEnemyId();
+    if (!enemyId) return;
+    const baseArea = byId("sandbox-advanced-base-json");
+    const overrideArea = byId("sandbox-advanced-override-json");
+    if (!baseArea || !overrideArea) return;
+
+    // Base JSON from GameData.enemies
+    let baseRow = null;
+    try {
+      const GD = (typeof window !== "undefined" ? window.GameData : null);
+      const list = GD && Array.isArray(GD.enemies) ? GD.enemies : null;
+      if (list) {
+        baseRow = list.find(e => e && String(e.id || "").toLowerCase() === String(enemyId).toLowerCase()) || null;
+      }
+    } catch (_) {
+      baseRow = null;
+    }
+    baseArea.value = baseRow ? JSON.stringify(baseRow, null, 2) : "";
+
+    // Override JSON from ctx.sandboxEnemyOverrides
+    const ctx = getCtxSafe();
+    let override = null;
+    if (ctx && ctx.sandboxEnemyOverrides && typeof ctx.sandboxEnemyOverrides === "object") {
+      override = ctx.sandboxEnemyOverrides[enemyId] || null;
+    }
+    overrideArea.value = override ? JSON.stringify(override, null, 2) : "";
+  } catch (_) {}
+}
+
+/**
+ * Spawn helper shared by Spawn 1 / Spawn N.
+ */
+function spawnWithCount(requestedCount) {
+  try {
+    if (!window.GameAPI) return;
+    const enemyId = currentEnemyId();
+    if (!enemyId) {
+      if (typeof window.GameAPI.log === "function") {
+        window.GameAPI.log("Sandbox: Enemy id is empty; cannot spawn.", "warn");
+      }
+      return;
+    }
+
+    let n = requestedCount;
+    if (n == null) {
+      const cntInput = byId("sandbox-enemy-count");
+      if (cntInput) {
+        n = (Number(cntInput.value) || 1) | 0;
+      } else {
+        n = 1;
+      }
+    }
+    if (n < 1) n = 1;
+    if (n > 50) n = 50;
+
+    let spawned = false;
+
+    // Preferred path: call God.spawnEnemyById directly with live ctx when available.
+    try {
+      if (typeof window.GameAPI.getCtx === "function" &&
+          typeof window.God === "object" &&
+          typeof window.God.spawnEnemyById === "function") {
+        const ctx = window.GameAPI.getCtx();
+        if (ctx && (ctx.mode === "sandbox" || ctx.mode === "dungeon")) {
+          spawned = !!window.God.spawnEnemyById(ctx, enemyId, n);
+        }
+      }
+    } catch (_) {
+      spawned = false;
+    }
+
+    // Fallback to GameAPI helper if direct GOD call was unavailable or failed.
+    if (!spawned && typeof window.GameAPI.spawnEnemyById === "function") {
+      spawned = !!window.GameAPI.spawnEnemyById(enemyId, n);
+    }
+
+    // Final fallback: random nearby spawn if by-id helpers are missing.
+    if (!spawned && typeof window.GameAPI.spawnEnemyNearby === "function") {
+      spawned = !!window.GameAPI.spawnEnemyNearby(n);
+      if (typeof window.GameAPI.log === "function") {
+        window.GameAPI.log("Sandbox: spawnEnemyById not available; used random spawnEnemyNearby instead.", "warn");
+      }
+    }
+
+    if (!spawned && typeof window.GameAPI.log === "function") {
+      window.GameAPI.log(`Sandbox: Failed to spawn enemy '${enemyId}'.`, "warn");
+    }
+  } catch (_) {}
+}
 
 function ensurePanel() {
   let el = byId("sandbox-panel");
@@ -114,12 +307,13 @@ function ensurePanel() {
         </button>
       </div>
 
-      <!-- Basic spawn -->
+      <!-- Basic enemy tuning & spawn -->
       <div style="margin-top:6px; padding-top:4px; border-top:1px solid #374151;">
         <div style="font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:#9ca3af; margin-bottom:4px;">
-          Basic Spawn
+          Basic / Default
         </div>
         <div style="display:flex; flex-direction:column; gap:4px;">
+          <!-- Selection -->
           <div style="display:flex; align-items:center; gap:4px;">
             <span style="font-size:11px; color:#9ca3af;">Enemy</span>
             <input id="sandbox-enemy-id" type="text"
@@ -130,20 +324,129 @@ function ensurePanel() {
             <button id="sandbox-enemy-next-btn" type="button"
               style="padding:2px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:10px; cursor:pointer;">▶</button>
           </div>
+
+          <!-- Test depth -->
           <div style="display:flex; align-items:center; gap:6px;">
+            <span style="font-size:11px; color:#9ca3af;">Test depth</span>
+            <input id="sandbox-test-depth" type="number" min="1" max="20" value="3"
+              style="width:60px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+          </div>
+
+          <!-- Visual / identity -->
+          <div style="display:flex; flex-wrap:wrap; gap:4px;">
+            <div style="display:flex; align-items:center; gap:4px; flex:1 1 40px;">
+              <span style="font-size:11px; color:#9ca3af;">Glyph</span>
+              <input id="sandbox-glyph" type="text" maxlength="1"
+                style="width:34px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px; text-align:center;" />
+            </div>
+            <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">
+              <span style="font-size:11px; color:#9ca3af;">Color</span>
+              <input id="sandbox-color" type="text"
+                placeholder="#8bd5a0"
+                style="flex:1; min-width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            </div>
+          </div>
+          <div style="display:flex; align-items:center; gap:4px;">
+            <span style="font-size:11px; color:#9ca3af;">Faction</span>
+            <input id="sandbox-faction" type="text"
+              placeholder="monster, bandit..."
+              style="flex:1; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+          </div>
+
+          <!-- Core combat knobs -->
+          <div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:2px;">
+            <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">
+              <span style="font-size:11px; color:#9ca3af;">HP @ depth</span>
+              <input id="sandbox-hp" type="number" min="1"
+                style="width:64px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            </div>
+            <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">
+              <span style="font-size:11px; color:#9ca3af;">ATK @ depth</span>
+              <input id="sandbox-atk" type="number" min="0"
+                style="width:64px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            </div>
+          </div>
+          <div style="display:flex; align-items:center; gap:4px;">
+            <span style="font-size:11px; color:#9ca3af;">XP @ depth</span>
+            <input id="sandbox-xp" type="number" min="0"
+              style="width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+          </div>
+
+          <div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:2px;">
+            <div style="display:flex; align-items:center; gap:4px; flex:1 1 90px;">
+              <span style="font-size:11px; color:#9ca3af;">Damage scale</span>
+              <input id="sandbox-damage-scale" type="number" step="0.1"
+                style="width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            </div>
+            <div style="display:flex; align-items:center; gap:4px; flex:1 1 90px;">
+              <span style="font-size:11px; color:#9ca3af;">Equip chance</span>
+              <input id="sandbox-equip-chance" type="number" step="0.05" min="0" max="1"
+                style="width:72px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            </div>
+          </div>
+
+          <!-- Spawn + override controls -->
+          <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
             <span style="font-size:11px; color:#9ca3af;">Count</span>
             <input id="sandbox-enemy-count" type="number" min="1" max="50" value="1"
               style="width:52px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
-            <button id="sandbox-spawn-btn" type="button"
-              style="flex:1; padding:4px 8px; border-radius:6px; border:1px solid #22c55e;
+            <button id="sandbox-spawn1-btn" type="button"
+              style="flex:1; padding:4px 6px; border-radius:6px; border:1px solid #22c55e;
                      background:#16a34a; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
-              Spawn
+              Spawn 1
+            </button>
+            <button id="sandbox-spawnn-btn" type="button"
+              style="flex:1; padding:4px 6px; border-radius:6px; border:1px solid #22c55e;
+                     background:#15803d; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
+              Spawn N
+            </button>
+          </div>
+
+          <div style="display:flex; gap:6px; margin-top:4px;">
+            <button id="sandbox-apply-override-btn" type="button"
+              style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
+                     background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
+              Apply as Override
+            </button>
+            <button id="sandbox-reset-override-btn" type="button"
+              style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
+                     background:#020617; color:#9ca3af; font-size:12px; cursor:pointer; text-align:center;">
+              Reset to Base
             </button>
           </div>
         </div>
       </div>
 
-      <!-- Advanced overrides (loot pools) removed: feature currently disabled -->
+      <!-- Advanced JSON overrides -->
+      <div style="margin-top:6px; padding-top:4px; border-top:1px solid #374151;">
+        <button id="sandbox-advanced-toggle-btn" type="button"
+          style="width:100%; padding:4px 8px; border-radius:6px; border:1px solid #4b5563;
+                 background:#020617; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:left;">
+          Advanced ▸
+        </button>
+        <div id="sandbox-advanced-body" style="display:none; margin-top:4px; display:flex; flex-direction:column; gap:4px;">
+          <div style="font-size:11px; color:#9ca3af;">Base JSON (read-only)</div>
+          <textarea id="sandbox-advanced-base-json" readonly
+            style="width:100%; min-height:80px; max-height:120px; padding:4px 6px; border-radius:4px;
+                   border:1px solid #4b5563; background:#020617; color:#9ca3af; font-size:11px; font-family:'JetBrains Mono',monospace;"></textarea>
+          <div style="font-size:11px; color:#9ca3af;">Override JSON (sandbox-only)</div>
+          <textarea id="sandbox-advanced-override-json"
+            style="width:100%; min-height:80px; max-height:140px; padding:4px 6px; border-radius:4px;
+                   border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:11px; font-family:'JetBrains Mono',monospace;"></textarea>
+          <div style="display:flex; gap:6px; margin-top:2px;">
+            <button id="sandbox-advanced-apply-json-btn" type="button"
+              style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
+                     background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
+              Apply JSON
+            </button>
+            <button id="sandbox-advanced-reset-json-btn" type="button"
+              style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
+                     background:#020617; color:#9ca3af; font-size:12px; cursor:pointer; text-align:center;">
+              Reset Override
+            </button>
+          </div>
+        </div>
+      </div>
 
     </div>
   `;
@@ -204,6 +507,7 @@ export function init(UI) {
       if (!_enemyTypes.length) return;
       _enemyIndex = (_enemyTypes.length + _enemyIndex - 1) % _enemyTypes.length;
       setEnemyId(_enemyTypes[_enemyIndex]);
+      syncBasicFormFromData();
     });
   }
   if (nextBtn) {
@@ -214,76 +518,207 @@ export function init(UI) {
       if (!_enemyTypes.length) return;
       _enemyIndex = (_enemyTypes.length + _enemyIndex + 1) % _enemyTypes.length;
       setEnemyId(_enemyTypes[_enemyIndex]);
+      syncBasicFormFromData();
     });
   }
 
-  // Enemy id manual input: no extra behavior needed now that advanced loot pools are removed
+  // Enemy id manual input => refresh tuning fields when changed
   const enemyInput = byId("sandbox-enemy-id");
   if (enemyInput) {
     enemyInput.addEventListener("change", () => {
-      // keep for future extension; no-op for now
+      syncBasicFormFromData();
     });
   }
 
-  // Spawn button
-  const spawnBtn = byId("sandbox-spawn-btn");
-  if (spawnBtn) {
-    spawnBtn.addEventListener("click", () => {
+  // Test depth change -> recompute suggested HP/ATK/XP
+  const depthInput = byId("sandbox-test-depth");
+  if (depthInput) {
+    depthInput.addEventListener("change", () => {
+      syncBasicFormFromData();
+    });
+  }
+
+  // Apply as Override
+  const applyBtn = byId("sandbox-apply-override-btn");
+  if (applyBtn) {
+    applyBtn.addEventListener("click", () => {
       try {
-        if (!window.GameAPI) return;
         const enemyId = currentEnemyId();
-        if (!enemyId) {
-          if (typeof window.GameAPI.log === "function") {
-            window.GameAPI.log("Sandbox: Enemy id is empty; cannot spawn.", "warn");
-          }
-          return;
-        }
-        const cntInput = byId("sandbox-enemy-count");
-        let n = 1;
-        if (cntInput) {
-          n = (Number(cntInput.value) || 1) | 0;
-        }
-        if (n < 1) n = 1;
-        if (n > 50) n = 50;
+        if (!enemyId) return;
+        const ctx = getCtxSafe();
+        if (!ctx) return;
 
-        let spawned = false;
+        const glyphInput = byId("sandbox-glyph");
+        const colorInput = byId("sandbox-color");
+        const factionInput = byId("sandbox-faction");
+        const hpInput = byId("sandbox-hp");
+        const atkInput = byId("sandbox-atk");
+        const xpInput = byId("sandbox-xp");
+        const dmgInput = byId("sandbox-damage-scale");
+        const eqInput = byId("sandbox-equip-chance");
+        const depthInput2 = byId("sandbox-test-depth");
 
-        // Preferred path: call God.spawnEnemyById directly with live ctx when available.
-        try {
-          if (typeof window.GameAPI.getCtx === "function" &&
-              typeof window.God === "object" &&
-              typeof window.God.spawnEnemyById === "function") {
-            const ctx = window.GameAPI.getCtx();
-            if (ctx && (ctx.mode === "sandbox" || ctx.mode === "dungeon")) {
-              spawned = !!window.God.spawnEnemyById(ctx, enemyId, n);
-            }
-          }
-        } catch (_) {
-          spawned = false;
-        }
+        const depth = depthInput2 ? ((Number(depthInput2.value) || 0) | 0) || 3 : 3;
 
-        // Fallback to GameAPI helper if direct GOD call was unavailable or failed.
-        if (!spawned && typeof window.GameAPI.spawnEnemyById === "function") {
-          spawned = !!window.GameAPI.spawnEnemyById(enemyId, n);
-        }
+        const overridesRoot = ctx.sandboxEnemyOverrides && typeof ctx.sandboxEnemyOverrides === "object"
+          ? ctx.sandboxEnemyOverrides
+          : (ctx.sandboxEnemyOverrides = Object.create(null));
 
-        // Final fallback: random nearby spawn if by-id helpers are missing.
-        if (!spawned && typeof window.GameAPI.spawnEnemyNearby === "function") {
-          spawned = !!window.GameAPI.spawnEnemyNearby(n);
-          if (typeof window.GameAPI.log === "function") {
-            window.GameAPI.log("Sandbox: spawnEnemyById not available; used random spawnEnemyNearby instead.", "warn");
-          }
-        }
+        const prev = overridesRoot[enemyId] || {};
+        const next = Object.assign({}, prev, {
+          testDepth: depth,
+        });
 
-        if (!spawned && typeof window.GameAPI.log === "function") {
-          window.GameAPI.log(`Sandbox: Failed to spawn enemy '${enemyId}'.`, "warn");
+        if (glyphInput) next.glyph = String(glyphInput.value || "");
+        if (colorInput) next.color = String(colorInput.value || "");
+        if (factionInput) next.faction = String(factionInput.value || "");
+        if (hpInput && hpInput.value !== "") next.hpAtDepth = Number(hpInput.value) || 1;
+        if (atkInput && atkInput.value !== "") next.atkAtDepth = Number(atkInput.value) || 0;
+        if (xpInput && xpInput.value !== "") next.xpAtDepth = Number(xpInput.value) || 0;
+        if (dmgInput && dmgInput.value !== "") next.damageScale = Number(dmgInput.value) || 1;
+        if (eqInput && eqInput.value !== "") next.equipChance = Number(eqInput.value) || 0;
+
+        overridesRoot[enemyId] = next;
+
+        if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(`Sandbox: Applied enemy override for '${enemyId}' (depth ${depth}).`, "notice");
         }
       } catch (_) {}
     });
   }
 
-  // Initialize button labels
+  // Reset override
+  const resetBtn = byId("sandbox-reset-override-btn");
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      try {
+        const enemyId = currentEnemyId();
+        if (!enemyId) return;
+        const ctx = getCtxSafe();
+        if (!ctx || !ctx.sandboxEnemyOverrides) {
+          syncBasicFormFromData();
+          return;
+        }
+        delete ctx.sandboxEnemyOverrides[enemyId];
+        if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(`Sandbox: Reset overrides for '${enemyId}' to base definition.`, "notice");
+        }
+        syncBasicFormFromData();
+        refreshAdvancedJson();
+      } catch (_) {}
+    });
+  }
+
+  // Spawn buttons
+  const spawn1Btn = byId("sandbox-spawn1-btn");
+  if (spawn1Btn) {
+    spawn1Btn.addEventListener("click", () => {
+      spawnWithCount(1);
+    });
+  }
+  const spawnNBtn = byId("sandbox-spawnn-btn");
+  if (spawnNBtn) {
+    spawnNBtn.addEventListener("click", () => {
+      spawnWithCount(null);
+    });
+  }
+
+  // Advanced toggle / JSON apply+reset
+  const advToggle = byId("sandbox-advanced-toggle-btn");
+  const advBody = byId("sandbox-advanced-body");
+  if (advToggle && advBody) {
+    advToggle.addEventListener("click", () => {
+      try {
+        const visible = advBody.style.display !== "none";
+        advBody.style.display = visible ? "none" : "flex";
+        advToggle.textContent = visible ? "Advanced ▸" : "Advanced ▾";
+        if (!visible) {
+          refreshAdvancedJson();
+        }
+      } catch (_) {}
+    });
+    // Start hidden
+    advBody.style.display = "none";
+  }
+
+  const advApplyBtn = byId("sandbox-advanced-apply-json-btn");
+  if (advApplyBtn) {
+    advApplyBtn.addEventListener("click", () => {
+      try {
+        const enemyId = currentEnemyId();
+        if (!enemyId) return;
+        const ctx = getCtxSafe();
+        if (!ctx) return;
+        const area = byId("sandbox-advanced-override-json");
+        if (!area) return;
+        const text = String(area.value || "").trim();
+        const overridesRoot = ctx.sandboxEnemyOverrides && typeof ctx.sandboxEnemyOverrides === "object"
+          ? ctx.sandboxEnemyOverrides
+          : (ctx.sandboxEnemyOverrides = Object.create(null));
+
+        if (!text) {
+          delete overridesRoot[enemyId];
+          if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+            window.GameAPI.log(`Sandbox: Cleared JSON override for '${enemyId}'.`, "notice");
+          }
+          syncBasicFormFromData();
+          refreshAdvancedJson();
+          return;
+        }
+
+        let parsed = null;
+        try {
+          parsed = JSON.parse(text);
+        } catch (e) {
+          if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+            window.GameAPI.log(`Sandbox: Failed to parse override JSON for '${enemyId}': ${e && e.message ? e.message : e}`, "warn");
+          }
+          return;
+        }
+        if (!parsed || typeof parsed !== "object") {
+          if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+            window.GameAPI.log(`Sandbox: Override JSON for '${enemyId}' must be an object.`, "warn");
+          }
+          return;
+        }
+
+        overridesRoot[enemyId] = parsed;
+        if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(`Sandbox: Applied JSON override for '${enemyId}'.`, "notice");
+        }
+        syncBasicFormFromData();
+        refreshAdvancedJson();
+      } catch (_) {}
+    });
+  }
+
+  const advResetBtn = byId("sandbox-advanced-reset-json-btn");
+  if (advResetBtn) {
+    advResetBtn.addEventListener("click", () => {
+      try {
+        const enemyId = currentEnemyId();
+        if (!enemyId) return;
+        const ctx = getCtxSafe();
+        if (!ctx || !ctx.sandboxEnemyOverrides) {
+          refreshAdvancedJson();
+          syncBasicFormFromData();
+          return;
+        }
+        delete ctx.sandboxEnemyOverrides[enemyId];
+        const area = byId("sandbox-advanced-override-json");
+        if (area) area.value = "";
+        if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
+          window.GameAPI.log(`Sandbox: Reset JSON override for '${enemyId}'.`, "notice");
+        }
+        syncBasicFormFromData();
+        refreshAdvancedJson();
+      } catch (_) {}
+    });
+  }
+
+  // Initialize button labels and basic form
   refreshAiToggle();
+  syncBasicFormFromData();
 }
 
 export function show() {
@@ -300,6 +735,7 @@ export function show() {
   } catch (_) {}
   // Refresh state when panel becomes visible
   refreshAiToggle();
+  syncBasicFormFromData();
 }
 
 export function hide() {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -335,15 +335,21 @@ function ensurePanel() {
           </div>
           <div style="display:flex; align-items:center; gap:4px;">
             <span style="font-size:11px; color:#9ca3af;"
-              title="Faction id used by AI/encounters (e.g. monster, bandit, guard). Sandbox override only.">
+              title="Faction id used by AI/encounters (e.g. monster, bandit, animal, guard). Sandbox override only.">
               Faction
             </span>
-            <input id="sandbox-faction" type="text"
-              placeholder="monster, bandit..."
-              title="Faction string for this enemy in sandbox (controls which side it fights for)."
-              style="flex:1; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
+            <select id="sandbox-faction"
+              title="Faction for this enemy in sandbox (controls which side it fights for)."
+              style="flex:1; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;">
+              <option value="">(none)</option>
+              <option value="monster">monster</option>
+              <option value="bandit">bandit</option>
+              <option value="animal">animal</option>
+              <option value="guard">guard</option>
+              <option value="orc">orc</option>
+              <option value="undead">undead</option>
+            </select>
           </div>
-
           <!-- Core combat knobs -->
           <div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:2px;">
             <div style="display:flex; align-items:center; gap:4px; flex:1 1 80px;">

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1510,7 +1510,7 @@ export function init(UI) {
           ? (Number(eqInput.value) || 0)
           : (baseRow && typeof baseRow.equipChance === "number" ? baseRow.equipChance : 0.35);
 
-        const tierVal = baseRow && typeof baseRow.tier === "number" ? baseRow.tier : 1;
+        let tierVal = baseRow && typeof baseRow.tier === "number" ? baseRow.tier : 1;
         // Prefer sandbox loot tier override when present for this enemy.
         try {
           const ctx0 = getCtxSafe();
@@ -1519,9 +1519,12 @@ export function init(UI) {
             if (ov0 && typeof ov0.equipTierOverride === "number") {
               const t0 = (ov0.equipTierOverride | 0);
               if (t0 >= 1 && t0 <= 3) {
-                // eslint-disable-next-line no-param-reassign
                 tierVal = t0;
               }
+            }
+          }
+        } catch (_) {}
+             }
             }
           }
         } catch (_) {}

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -424,13 +424,13 @@ function ensurePanel() {
               title="Save the Basic fields as a sandbox-only override for this enemy (affects future spawns in this session)."
               style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
                      background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
-              Apply as Override
+              Apply
             </button>
             <button id="sandbox-reset-override-btn" type="button"
               title="Remove the sandbox override for this enemy and fall back to its base JSON definition."
               style="flex:1; padding:3px 6px; border-radius:6px; border:1px solid #4b5563;
-                     background:#020617; color:#9ca3af; font-size:12px; cursor:pointer; text-align:center;">
-              Reset to Base
+                     background:#111827; color:#e5e7eb; font-size:12px; cursor:pointer; text-align:center;">
+              Reset
             </button>
           </div>
         </div>
@@ -526,8 +526,51 @@ export function init(UI) {
     });
   }
 
-  // Apply as Override
+  // Primary button visuals (Apply / Reset)
   const applyBtn = byId("sandbox-apply-override-btn");
+  const resetBtn = byId("sandbox-reset-override-btn");
+
+  function wirePrimarySandboxButton(btn) {
+    if (!btn) return;
+    // Base visual style
+    try {
+      btn.style.transition = "background 120ms ease, transform 80ms ease, box-shadow 120ms ease, border-color 120ms ease";
+      btn.style.boxShadow = "0 1px 4px rgba(15,23,42,0.75)";
+    } catch (_) {}
+    // Hover
+    btn.addEventListener("mouseenter", () => {
+      try {
+        btn.style.background = "#1e293b";
+        btn.style.borderColor = "#6b7280";
+      } catch (_) {}
+    });
+    btn.addEventListener("mouseleave", () => {
+      try {
+        btn.style.background = "#111827";
+        btn.style.borderColor = "#4b5563";
+        btn.style.transform = "translateY(0px)";
+        btn.style.boxShadow = "0 1px 4px rgba(15,23,42,0.75)";
+      } catch (_) {}
+    });
+    // Active (click)
+    btn.addEventListener("mousedown", () => {
+      try {
+        btn.style.transform = "translateY(1px)";
+        btn.style.boxShadow = "0 0 0 rgba(0,0,0,0.5)";
+      } catch (_) {}
+    });
+    btn.addEventListener("mouseup", () => {
+      try {
+        btn.style.transform = "translateY(0px)";
+        btn.style.boxShadow = "0 1px 4px rgba(15,23,42,0.75)";
+      } catch (_) {}
+    });
+  }
+
+  wirePrimarySandboxButton(applyBtn);
+  wirePrimarySandboxButton(resetBtn);
+
+  // Apply override
   if (applyBtn) {
     applyBtn.addEventListener("click", () => {
       try {
@@ -576,7 +619,6 @@ export function init(UI) {
   }
 
   // Reset override
-  const resetBtn = byId("sandbox-reset-override-btn");
   if (resetBtn) {
     resetBtn.addEventListener("click", () => {
       try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -1313,7 +1313,9 @@ export function init(UI) {
           ? ctx.sandboxEnemyOverrides
           : (ctx.sandboxEnemyOverrides = Object.create(null));
 
-        const prev = overridesRoot[enemyId] || {};
+        const idKey = String(enemyId);
+        const idLower = idKey.toLowerCase();
+        const prev = overridesRoot[idKey] || overridesRoot[idLower] || {};
         const next = Object.assign({}, prev, {
           testDepth: depth,
         });
@@ -1390,7 +1392,11 @@ export function init(UI) {
           delete next.lootPools;
         }
 
-        overridesRoot[enemyId] = next;
+        // Store override under both exact id and lower-case alias so loot
+        // helpers (which often lower-case type ids) can still resolve
+        // sandbox-only overrides reliably.
+        overridesRoot[idKey] = next;
+        if (idLower !== idKey) overridesRoot[idLower] = next;
 
         if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
           window.GameAPI.log(`Sandbox: Applied enemy override for '${enemyId}' (depth ${depth}).`, "notice");
@@ -1410,7 +1416,10 @@ export function init(UI) {
           syncBasicFormFromData();
           return;
         }
-        delete ctx.sandboxEnemyOverrides[enemyId];
+        const idKey = String(enemyId);
+        const idLower = idKey.toLowerCase();
+        delete ctx.sandboxEnemyOverrides[idKey];
+        if (idLower !== idKey) delete ctx.sandboxEnemyOverrides[idLower];
         if (typeof window.GameAPI === "object" && typeof window.GameAPI.log === "function") {
           window.GameAPI.log(`Sandbox: Reset overrides for '${enemyId}' to base definition.`, "notice");
         }

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/sandbox_panel.js
@@ -335,11 +335,11 @@ function ensurePanel() {
           <!-- Test depth -->
           <div style="display:flex; align-items:center; gap:6px;">
             <span style="font-size:11px; color:#9ca3af;"
-              title="Depth (floor) used to compute HP/ATK/XP from this enemy’s curves for sandbox tests. Does not change actual dungeon depth.">
+              title="Sandbox-only: dungeon depth (floor number) to sample this enemy’s HP/ATK/XP curves from JSON. Real runs use the actual floor; changing this does not move you.">
               Test depth
             </span>
             <input id="sandbox-test-depth" type="number" min="1" max="20" value="3"
-              title="Depth used when resolving this enemy’s HP/ATK/XP curves during sandbox spawns."
+              title="Dungeon depth (floor) to test this enemy at in sandbox. Affects only HP/ATK/XP used for these spawns; does not change the real dungeon floor."
               style="width:60px; padding:3px 4px; border-radius:4px; border:1px solid #4b5563; background:#020617; color:#e5e7eb; font-size:12px;" />
           </div>
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render/dungeon_entities_draw.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/render/dungeon_entities_draw.js
@@ -22,7 +22,9 @@ export function drawEnemies(ctx, view) {
     // look consistent across dungeon, town, and region maps.
     const isFollower = !!(e && e._isFollower);
     let glyph = e.glyph || "e";
-    let color = RenderCore.enemyColor(ctx, e.type, COLORS);
+    let color = (e && typeof e.color === "string" && e.color.trim().length)
+      ? e.color
+      : RenderCore.enemyColor(ctx, e.type, COLORS);
     if (isFollower) {
       const fid = e._followerId;
       const def = fid ? getFollowerDef(ctx, fid) : null;

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/ui.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/ui.js
@@ -51,6 +51,8 @@ export const UI = {
     // World teleport helpers
     onGodTeleportToTower: null,
     onGodTeleport: null,
+    // Sandbox helpers
+    onGodEnterSandbox: null,
   },
 
   init() {
@@ -290,7 +292,7 @@ export const UI = {
 
   
 
-  setHandlers({ onEquip, onEquipHand, onUnequip, onDrink, onEat, onRestart, onWait, onGodHeal, onGodSpawn, onGodSetFov, onGodSetEncounterRate, onGodSpawnEnemy, onGodSpawnStairs, onGodHireFollower, onGodSetAlwaysCrit, onGodSetCritPart, onGodToggleInvincible, onGodApplySeed, onGodRerollSeed, onGodCheckHomes, onGodCheckInnTavern, onGodCheckSigns, onGodCheckPrefabs, onGodDiagnostics, onGodRunSmokeTest, onGodRunValidation, onGodToggleGrid, onGodApplyBleed, onGodApplyDazed, onGodClearEffects, onGodStartEncounterNow, onGodArmEncounterNextMove, onGodTownBandits, onGodTeleportToTower, onGodTeleport } = {}) {
+  setHandlers({ onEquip, onEquipHand, onUnequip, onDrink, onEat, onRestart, onWait, onGodHeal, onGodSpawn, onGodSetFov, onGodSetEncounterRate, onGodSpawnEnemy, onGodSpawnStairs, onGodHireFollower, onGodSetAlwaysCrit, onGodSetCritPart, onGodToggleInvincible, onGodApplySeed, onGodRerollSeed, onGodCheckHomes, onGodCheckInnTavern, onGodCheckSigns, onGodCheckPrefabs, onGodDiagnostics, onGodRunSmokeTest, onGodRunValidation, onGodToggleGrid, onGodApplyBleed, onGodApplyDazed, onGodClearEffects, onGodStartEncounterNow, onGodArmEncounterNextMove, onGodTownBandits, onGodTeleportToTower, onGodTeleport, onGodEnterSandbox } = {}) {
     if (typeof onEquip === "function") this.handlers.onEquip = onEquip;
     if (typeof onEquipHand === "function") this.handlers.onEquipHand = onEquipHand;
     if (typeof onUnequip === "function") this.handlers.onUnequip = onUnequip;
@@ -326,10 +328,13 @@ export const UI = {
     if (typeof onGodTeleportToTower === "function") this.handlers.onGodTeleportToTower = onGodTeleportToTower;
     if (typeof onGodTeleport === "function") this.handlers.onGodTeleport = onGodTeleport;
 
-    // Extra handler (added later) for applying a status effect via GOD panel.
+    // Extra handlers (added later) for applying status effects or sandbox actions via GOD panel.
     const extra = arguments[0] || {};
     if (typeof extra.onGodApplyStatusEffect === "function") {
       this.handlers.onGodApplyStatusEffect = extra.onGodApplyStatusEffect;
+    }
+    if (typeof extra.onGodEnterSandbox === "function") {
+      this.handlers.onGodEnterSandbox = extra.onGodEnterSandbox;
     }
   },
 

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/ui.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/ui.js
@@ -29,6 +29,7 @@ import * as GodPanel from "/ui/components/god_panel.js";
 import * as InventoryPanel from "/ui/components/inventory_panel.js";
 import * as LootPanel from "/ui/components/loot_panel.js";
 import * as Hud from "/ui/components/hud.js";
+import * as SandboxPanel from "/ui/components/sandbox_panel.js";
 
 export const UI = {
   els: {},
@@ -53,6 +54,7 @@ export const UI = {
     onGodTeleport: null,
     // Sandbox helpers
     onGodEnterSandbox: null,
+    onToggleSandboxPanel: null,
   },
 
   init() {
@@ -152,6 +154,8 @@ export const UI = {
 
     // GOD panel wiring moved to component
     try { if (GodPanel && typeof GodPanel.init === "function") GodPanel.init(this); } catch (_) {}
+    // Sandbox controls panel (F10, sandbox-only)
+    try { if (SandboxPanel && typeof SandboxPanel.init === "function") SandboxPanel.init(this); } catch (_) {}
     // Inventory panel wiring moved to component
     try { if (InventoryPanel && typeof InventoryPanel.init === "function") InventoryPanel.init(this); } catch (_) {}
     this.updateSeedUI();
@@ -292,7 +296,7 @@ export const UI = {
 
   
 
-  setHandlers({ onEquip, onEquipHand, onUnequip, onDrink, onEat, onRestart, onWait, onGodHeal, onGodSpawn, onGodSetFov, onGodSetEncounterRate, onGodSpawnEnemy, onGodSpawnStairs, onGodHireFollower, onGodSetAlwaysCrit, onGodSetCritPart, onGodToggleInvincible, onGodApplySeed, onGodRerollSeed, onGodCheckHomes, onGodCheckInnTavern, onGodCheckSigns, onGodCheckPrefabs, onGodDiagnostics, onGodRunSmokeTest, onGodRunValidation, onGodToggleGrid, onGodApplyBleed, onGodApplyDazed, onGodClearEffects, onGodStartEncounterNow, onGodArmEncounterNextMove, onGodTownBandits, onGodTeleportToTower, onGodTeleport, onGodEnterSandbox } = {}) {
+  setHandlers({ onEquip, onEquipHand, onUnequip, onDrink, onEat, onRestart, onWait, onGodHeal, onGodSpawn, onGodSetFov, onGodSetEncounterRate, onGodSpawnEnemy, onGodSpawnStairs, onGodHireFollower, onGodSetAlwaysCrit, onGodSetCritPart, onGodToggleInvincible, onGodApplySeed, onGodRerollSeed, onGodCheckHomes, onGodCheckInnTavern, onGodCheckSigns, onGodCheckPrefabs, onGodDiagnostics, onGodRunSmokeTest, onGodRunValidation, onGodToggleGrid, onGodApplyBleed, onGodApplyDazed, onGodClearEffects, onGodStartEncounterNow, onGodArmEncounterNextMove, onGodTownBandits, onGodTeleportToTower, onGodTeleport, onGodEnterSandbox, onToggleSandboxPanel } = {}) {
     if (typeof onEquip === "function") this.handlers.onEquip = onEquip;
     if (typeof onEquipHand === "function") this.handlers.onEquipHand = onEquipHand;
     if (typeof onUnequip === "function") this.handlers.onUnequip = onUnequip;
@@ -335,6 +339,9 @@ export const UI = {
     }
     if (typeof extra.onGodEnterSandbox === "function") {
       this.handlers.onGodEnterSandbox = extra.onGodEnterSandbox;
+    }
+    if (typeof extra.onToggleSandboxPanel === "function") {
+      this.handlers.onToggleSandboxPanel = extra.onToggleSandboxPanel;
     }
   },
 


### PR DESCRIPTION
Adds core/sandbox/runtime.js which exports SandboxRuntime and its enter(ctx, options) method for quick, isolated sandbox testing.

What it does:
- Builds a simple rectangular room (walls on the border, floor inside) and swaps the active map with this test room.
- Replaces visibility/data arrays (map, seen, visible) and resets per-map collections (enemies, npcs, townProps, corpses, dungeonProps, decals).
- Enables sandbox mode flags (ctx.mode, ctx.isSandbox, sandboxFlags) and centers the player in the room.
- Attempts to refresh UI/game state by calling recomputeFOV, updateCamera, updateUI, and requestDraw if those helpers exist.
- Attaches SandboxRuntime globally for use by module loaders (Ctx.attachModules).

Notes:
- This is an experimental MVP sandbox mode intended for focused testing. It does not save/restore prior game state; exiting uses the normal restart/new-game flow.
- Useful for quickly validating rendering, UI, and camera behavior in a contained room.


---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/7fvlg9wje7cb](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/7fvlg9wje7cb)
Author: zakker111
