### PR TITLE
Add charisma-based pricing, luck-influenced loot drops, and attribute system with UI support

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/BUGS.md
@@ -61,3 +61,11 @@
   - During the bandits-at-the-gate town event, pressing G while standing on some guard/bandit corpses near the gate reports nothing to loot or shows only flavor, with no items or gold granted.
   - This likely indicates a mismatch between town-mode corpse records (ctx.corpses), the Loot subsystem, and the town-mode loot path in core/modes/actions.js::loot(ctx) around the bandit event flows.
   - Needs focused repro in a fresh town with an active bandits-at-the-gate event to confirm whether corpses are spawned without loot, or whether the lootHere/loot(ctx) path is not being invoked correctly in town mode for those specific corpses.
+- While the lockpicking mini-game is open, some keyboard movement keys still move the player:
+  - Arrow keys and certain Numpad keys (1–7) may continue to move the player character even though the lockpicking overlay is active.
+  - Expected: while the lockpicking modal is open, world/region/dungeon movement keys should be swallowed so the player cannot walk around during the puzzle.
+  - Needs input handling audit so LockpickModal correctly blocks arrow and numpad movement from reaching the core input/movement handlers.
+- Loot sometimes logs that an item was "equipped" without actually changing player equipment:
+  - After looting corpses/chests, the log occasionally reports entries like "equipped [item desc]" but the corresponding slot on the player remains unchanged.
+  - This suggests a mismatch between ctx.equipIfBetter/autoequip behavior in entities/loot.js and the inventory/equipment update path used by Player/PlayerEquip.
+  - Needs a focused repro with logging around Loot.lootHere(ctx) to verify when equipIfBetter returns true vs when inventory/equipment actually change.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/FEATURES.md
@@ -684,6 +684,28 @@ These exist partially in code or design but are **known unstable** or not yet im
     - World generation and expansion can become slow/sluggish as more chunks are visited.
   - Tracked as a bug in `BUGS.md` and targeted for future performance work in world/infinite_gen + world_runtime.
 
+### 12.6 Attribute system & Character Sheet (EXPERIMENTAL)
+
+- Character attributes and the Character Sheet are wired into core systems but are still considered **experimental** and subject to tuning.
+- The Character Sheet (`C`) shows five core attributes and an unspent points pool:
+  - **STR (Strength)** — melee offense:
+    - Increases base melee Attack; every few points of STR add a small flat bonus to attack power.
+    - Affects all bump-attacks via the shared `Player.getAttack` helper.
+  - **DEX (Dexterity)** — accuracy and avoidance:
+    - When you attack: slightly reduces enemy block chance and slightly increases your critical hit chance.
+    - When enemies hit you: grants a small extra damage reduction on top of armor DR.
+  - **INT (Intellect)** — utility and finesse:
+    - Lockpicking mini-game: adds extra move budget and a few extra fine nudges based on INT.
+    - Foraging on the Region Map: small INT-based chance to gain extra berries from bushes and extra planks from trees.
+  - **CHA (Charisma)** — economy:
+    - Improves shop prices: reduces buy prices and increases sell payouts through `ShopService` helpers.
+    - Currently does **not** discount inn room services to avoid surprising behavior.
+  - **LCK (Luck)** — loot quality:
+    - Slightly increases the chance for defeated enemies to drop equipment (higher LCK → more frequent gear drops over time).
+- Attribute points:
+  - Level-ups grant a small number of attribute points; the Character Sheet includes `+/-` buttons as a **developer-facing cheat UI** to spend/refund points during testing.
+  - Long-term progression rules (how many points per level, caps, and respec rules) are still in flux and may change.
+
 ---
 
 ## 13. Platform & Input

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -58,6 +58,21 @@ This file collects planned features, ideas, and technical cleanups that were pre
 - [ ] Player skill tree and skill points
   - Perception skill that affects how far the player sees other creatures/enemies, and how early encounters/animals are sensed.
   - “Campman” / survival skill affecting animal sensing and how often the player can safely flee from encounters.
+- [ ] Follower attribute preferences (faction/archetype driven, visible/hidden)
+  - Design and implement a simple attribute system for followers that mirrors (or reuses) the player attribute model.
+  - On follower level-up, automatically allocate follower attribute points according to their faction/archetype:
+    - Guard-style followers prioritize STR/CON-style toughness and DEX for blocking.
+    - Thief/rogue followers favor DEX and INT for accuracy, crits, and utility (lockpicking/foraging).
+    - Caster/support-style followers (if introduced) would favor INT/CHA.
+  - Decide whether follower attributes are:
+    - Fully visible on a follower inspect panel (explicit STR/DEX/INT/CHA/LCK lines), or
+    - Mostly hidden, with only summarized effects shown (e.g., “Prefers agility and precision”).
+  - Ensure follower attribute spending is data-driven:
+    - Define simple per-archetype weights or priority lists in JSON (e.g., `attributes: { str: 2, dex: 3, int: 1 }`).
+    - Runtime level-up logic distributes points using these weights so different factions feel distinct without hardcoding per-follower behavior.
+  - Keep this system optional/low-noise for players:
+    - Default UI only needs to show high-level effects (Attack, Defense, role description);
+      raw attribute lines can remain a debug/EXPERIMENTAL view until the system is stable.
 - [ ] Passive combat skills
   - One-handed, two-handed, shield use, and striking skills that grow with use up to a cap and affect combat stats.
 - [ ] Deeper character sheet and lasting injuries

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -93,6 +93,18 @@ This file collects planned features, ideas, and technical cleanups that were pre
   - Integrate with healing systems:
     - Normal rest/potions handle temporary HP/status.
     - Permanent injuries require special treatment (see healer below).
+- [ ] Remove or gate auto-equip behavior once testing is complete
+  - Auto-equipping "best" gear on loot is currently helpful for testing and quick progression but can feel intrusive or confusing for players.
+  - Plan to remove or strictly gate auto-equip so that:
+    - Normal runs favor explicit player choice via the inventory/equipment UI instead of silent auto-upgrades.
+    - Any remaining auto-equip paths (e.g., debug flows, GOD tools, smoketests) are clearly marked as testing-only and not used in normal gameplay.
+  - Review Loot.lootHere(ctx) and PlayerEquip.equipIfBetter usage so that production paths only equip when the player explicitly chooses to.
+- [ ] Weight / encumbrance system for player and followers
+  - Introduce a simple weight or encumbrance model so the player (and followers) cannot carry every item indefinitely without tradeoffs.
+  - Assign weight values to equipment and loot (data-driven in items JSON) and track total carried weight per actor.
+  - Define clear effects of encumbrance (e.g., slower movement, reduced dodge/DEX benefits, or hard item caps) and ensure they are explained in the Character/Follower sheets.
+  - Extend inventory/loot flows so picking up items respects weight limits and forces meaningful choices about what to carry, stash, or leave behind.
+  - Ensure follower inventories and auto-loot behavior also honor weight limits, preventing followers from acting as infinite backpacks.
 - [ ] Healer / surgeon NPC for permanent injuries
   - Add a dedicated healer (e.g., in towns or temples) who can treat permanent injuries for gold.
   - Healing options:

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -73,9 +73,9 @@ This file collects planned features, ideas, and technical cleanups that were pre
   - Keep this system optional/low-noise for players:
     - Default UI only needs to show high-level effects (Attack, Defense, role description);
       raw attribute lines can remain a debug/EXPERIMENTAL view until the system is stable.
-- [ ] Player level / attribute caps and respec limits
-  - Introduce a clear maximum player level (soft and/or hard cap) so combat and economy remain tunable at late game.
-  - Add per-attribute caps (either global or per-attribute) so single stats cannot be pushed to absurd values.
+- [ ] Player / follower level caps, attribute caps, and respec limits
+  - Introduce clear maximum levels (soft and/or hard caps) for both the player and followers so combat and economy remain tunable at late game.
+  - Add per-attribute caps (either global or per-attribute) so single stats cannot be pushed to absurd values on either the player or followers.
   - Define strict respec rules:
     - Attribute points should not be freely and repeatedly respec’d from the Character Sheet during normal runs.
     - Consider rare/expensive respec options (e.g., special shrine/NPC, high gold cost, or limited-use items) instead of free point shuffling.

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -105,6 +105,13 @@ This file collects planned features, ideas, and technical cleanups that were pre
   - Define clear effects of encumbrance (e.g., slower movement, reduced dodge/DEX benefits, or hard item caps) and ensure they are explained in the Character/Follower sheets.
   - Extend inventory/loot flows so picking up items respects weight limits and forces meaningful choices about what to carry, stash, or leave behind.
   - Ensure follower inventories and auto-loot behavior also honor weight limits, preventing followers from acting as infinite backpacks.
+- [ ] Difficulty scaling that accounts for player attributes
+  - Now that STR/DEX/INT/CHA/LCK affect combat, shops, and loot, revisit difficulty curves so enemies remain interesting and not trivial at high attribute values.
+  - Define a simple notion of "effective power" for the player that includes level, gear, and attributes, and use it to:
+    - Adjust encounter composition and enemy tiers (especially in late game or deep dungeons).
+    - Tune enemy HP/ATK multipliers so high-attribute builds still face meaningful threats.
+  - Ensure scaling remains data-driven (e.g., via combat/balance JSON) so attribute-impact tuning does not require hard-coded changes.
+  - Keep early game forgiving, but avoid situations where stacked attributes make most fights completely effortless.
 - [ ] Healer / surgeon NPC for permanent injuries
   - Add a dedicated healer (e.g., in towns or temples) who can treat permanent injuries for gold.
   - Healing options:

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/TODO.md
@@ -73,6 +73,13 @@ This file collects planned features, ideas, and technical cleanups that were pre
   - Keep this system optional/low-noise for players:
     - Default UI only needs to show high-level effects (Attack, Defense, role description);
       raw attribute lines can remain a debug/EXPERIMENTAL view until the system is stable.
+- [ ] Player level / attribute caps and respec limits
+  - Introduce a clear maximum player level (soft and/or hard cap) so combat and economy remain tunable at late game.
+  - Add per-attribute caps (either global or per-attribute) so single stats cannot be pushed to absurd values.
+  - Define strict respec rules:
+    - Attribute points should not be freely and repeatedly respec’d from the Character Sheet during normal runs.
+    - Consider rare/expensive respec options (e.g., special shrine/NPC, high gold cost, or limited-use items) instead of free point shuffling.
+  - Keep the current +/- Character Sheet controls as a debug/EXPERIMENTAL tool only; wire them behind a clear dev flag once proper respec rules exist.
 - [ ] Passive combat skills
   - One-handed, two-handed, shield use, and striking skills that grow with use up to a cap and affect combat stats.
 - [ ] Deeper character sheet and lasting injuries

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/VERSIONS.md
@@ -1,3 +1,42 @@
+2026-02-09 — Player attribute system, Character Sheet, and early STR/DEX/INT/CHA/LCK integration
+
+- Added an experimental player attribute system with five core stats and an unspent point pool:
+  - **STR (Strength)** — melee offense:
+    - Increases base melee Attack; every few points of STR add a small flat bonus to attack power via `Player.getAttack`.
+  - **DEX (Dexterity)** — accuracy and avoidance:
+    - When the player attacks: slightly reduces enemy block chance and slightly increases critical hit chance in `combat/combat.js::playerAttackEnemy`.
+    - When enemies hit the player: grants a small extra damage reduction layered on top of armor DR in `enemyDamageAfterDefense`.
+  - **INT (Intellect)** — utility and finesse:
+    - Lockpicking mini-game (`ui/components/lockpick_modal.js`): INT adds extra total moves and extra fine nudges.
+    - Region Map foraging (`region_map/region_map_actions.js`): INT gives a small chance to gain extra berries from bushes and extra planks from trees.
+  - **CHA (Charisma)** — economy:
+    - ShopService uses CHA to adjust buy/sell prices, giving discounts on purchases and better sell payouts (inn room prices intentionally unaffected).
+  - **LCK (Luck)** — loot quality:
+    - Slightly increases the chance for equipment drops from enemies (higher LCK ⇒ more frequent gear over time).
+- Level-ups now grant a small number of attribute points, tracked on the player and shown in the Character Sheet.
+- Character Sheet (`ui/components/character_modal.js`):
+  - Shows current attributes and unspent attribute points alongside HP/Attack/Defense, injuries, skills, and followers.
+  - Includes +/- buttons as a **developer-facing cheat UI** to spend/refund attribute points for testing; this is documented as experimental and slated to be gated/removed for normal play.
+- Combat integration:
+  - `entities/player.js::getAttack` uses STR to add a small flat attack bonus on top of base ATK, gear, and level scaling.
+  - `combat/combat.js::playerAttackEnemy` reads DEX from `ctx.player.attributes.dex` and:
+    - Reduces enemy block chance by up to ~20% relative at very high DEX.
+    - Adds a small absolute crit chance bonus (capped, still clamped to an overall 60% crit chance).
+  - `combat/combat.js::enemyDamageAfterDefense` adds a DEX-based damage reduction bonus (up to ~10% extra DR) after armor DR.
+- Non-combat integration:
+  - Lockpicking: `LockpickModal.setupPuzzle` now adds INT-based bonuses on top of lockpicking skill, giving extra move budget and fine nudges.
+  - Region Map foraging: berry bushes and trees call new helpers (`getIntAttribute`, `chanceIntBonus`) so INT can occasionally grant extra berries/planks using RNGUtils and ctx.rng (no Math.random in core flows).
+- Documentation and planning:
+  - FEATURES.md now includes an **Attribute system & Character Sheet (EXPERIMENTAL)** section describing STR/DEX/INT/CHA/LCK effects and the cheat UI.
+  - TODO.md gained entries for:
+    - Follower attribute preferences (archetype/faction-driven attribute spending, visible/hidden in follower panels).
+    - Player/follower level caps and per-attribute caps, plus stricter respec rules (current +/- controls are marked as debug-only).
+    - Removing/gating auto-equip behavior so explicit player choice drives equipment in normal runs.
+    - Weight/encumbrance system for player and followers, including equipment/loot weights and encumbrance effects.
+    - Difficulty scaling that takes attributes into account so high-attribute builds still face interesting fights.
+- BUGS.md additions:
+  - Recorded that some movement keys (arrow keys and Numpad 1–7) can still move the player while the lockpicking mini-game is open, and that loot logs sometimes say an item was "equipped" without equipment actually changing, both slated for investigation.
+
 2026-02-08 — File size snapshot (Top 10 largest files)
 
 Top 10 largest files in the repo

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/entities/loot.js
@@ -391,7 +391,21 @@ export function generate(ctx, source) {
       }
     }
   } catch (_) {}
-  if (ctx.chance(equipChance)) {
+
+  // Luck slightly increases the chance to drop equipment.
+  let finalEquipChance = equipChance;
+  try {
+    const p = ctx && ctx.player ? ctx.player : null;
+    const attrs = p && p.attributes ? p.attributes : null;
+    const lck = attrs && typeof attrs.lck === "number" ? attrs.lck : 0;
+    const n = lck | 0;
+    const nonNeg = n < 0 ? 0 : n;
+    // 1% absolute bonus per LCK, capped at +20%
+    const bonus = Math.min(0.2, nonNeg * 0.01);
+    finalEquipChance = Math.min(1, Math.max(0, equipChance + bonus));
+  } catch (_) {}
+
+  if (ctx.chance(finalEquipChance)) {
     // Only use enemy-specific loot pool; no general fallback
     const biased = pickEnemyBiasedEquipment(ctx, type, tier);
     if (biased) {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/lockpick_modal.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/components/lockpick_modal.js
@@ -230,6 +230,19 @@ function setupPuzzle(ctx, opts) {
   _fineLimit = 1 + Math.max(0, fineExtra);
   _fineUsed = 0;
 
+  // INT: slight bonus to move and fine-nudge budget.
+  try {
+    const p = ctx && ctx.player ? ctx.player : null;
+    const attrs = p && p.attributes ? p.attributes : null;
+    const intVal = attrs && typeof attrs.int === "number" ? attrs.int : 0;
+    const n = intVal | 0;
+    const nonNeg = n < 0 ? 0 : n;
+    const intMovesBonus = Math.min(4, Math.floor(nonNeg / 5));   // +1 move per 5 INT, up to +4
+    const intFineBonus  = Math.min(2, Math.floor(nonNeg / 10));  // +1 fine per 10 INT, up to +2
+    _movesLimit += intMovesBonus;
+    _fineLimit = Math.max(0, (_fineLimit | 0) + intFineBonus);
+  } catch (_) {}
+
   _pins = [];
   for (let c = 0; c < _cols; c++) {
     let row = Math.floor(Math.random() * _rows);

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/shop_panel.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ui/shop_panel.js
@@ -87,10 +87,16 @@ function listSellables(ctx) {
       // Show estimated sell price using rules
       let est = 5;
       try {
-        const phase = (window.ShopService && typeof window.ShopService.getPhase === "function") ? window.ShopService.getPhase(ctx) : "morning";
-        const base = (window.ShopService && typeof window.ShopService.calculatePrice === "function") ? window.ShopService.calculatePrice((_shopRef && _shopRef.type) || "trader", it, phase, null) : 10;
-        const rules = (window.GameData && window.GameData.shopRules && _shopRef && window.GameData.shopRules[_shopRef.type]) ? window.GameData.shopRules[_shopRef.type] : { buyMultiplier: 0.5 };
-        est = Math.max(1, Math.round(base * (rules.buyMultiplier || 0.5)));
+        if (window.ShopService && typeof window.ShopService.getSellPrice === "function" && _shopRef) {
+          est = window.ShopService.getSellPrice(ctx, _shopRef, it) | 0;
+          if (est < 1) est = 1;
+        } else {
+          // Fallback: replicate old estimate path if helper is missing (back-compat)
+          const phase = (window.ShopService && typeof window.ShopService.getPhase === "function") ? window.ShopService.getPhase(ctx) : "morning";
+          const base = (window.ShopService && typeof window.ShopService.calculatePrice === "function") ? window.ShopService.calculatePrice((_shopRef && _shopRef.type) || "trader", it, phase, null) : 10;
+          const rules = (window.GameData && window.GameData.shopRules && _shopRef && window.GameData.shopRules[_shopRef.type]) ? window.GameData.shopRules[_shopRef.type] : { buyMultiplier: 0.5 };
+          est = Math.max(1, Math.round(base * (rules.buyMultiplier || 0.5)));
+        }
       } catch (_) {}
       out.push({ idx: i, item: it, price: est });
     }


### PR DESCRIPTION
Summary:
- Introduces a lightweight attribute system (STR, DEX, INT, CHA, LCK) with unspent attribute points and UI to allocate points
- Adds luck-based adjustments to loot drop chances and STR-based attack bonus
- Implements charisma-driven buy/sell pricing in shops with UI updates and price calculations
- Refactors shop inventory pricing flow to present CHA-adjusted prices to the UI without mutating internal state
- Keeps compatibility and safety with try/catch guards around new logic

What changed, file by file:
- entities/loot.js
  - Enhance equipment drop chance: finalEquipChance is computed by applying a luck-based bonus from the player’s LCK attribute (up to +20%). This boosts the probability of equipment drops when luck is high.
  - Uses finalEquipChance to decide whether to pull from the enemy equipment pool, maintaining existing behavior for failure cases.

- entities/player.js
  - Added defaults for attributes: str, dex, int, cha, lck, plus attributePoints.
  - normalize(p): Normalize and clamp all base attributes and attributePoints to non-negative integers.
  - getAttack(player): Added str-based bonus: floor(lack of strength) contributes a small attack bonus (str/3).
  - gainXP(player, ...): Award attributePoints per level (3 per level) and ensure attributePoints is a valid number; initialize when missing.

- services/shop_service.js
  - Add charisma helpers: _getCharisma, _buyPriceMultiplierForCharisma, _sellPriceMultiplierForCharisma, _computeSellPay.
  - _computeSellPay calculates sell price using base price calculations, buy multipliers, and CHA-based sell multipliers (up to +30%).
  - Exported getSellPrice(ctx, shop, item) to allow UI/layers to fetch CHA-adjusted sell price without mutating state.
  - Adjusted buyItem and sellItem logic to apply finalPrice or computed pay using CHA multipliers, and to log the actual price shown to the user.
  - getInventoryForShop(ctx, shop) now returns prices adjusted by CHA multiplier (without mutating internal rows).
  - rest of pricing logic remains backward-compatible when CHA data is unavailable.

- ui/components/character_modal.js
  - Injected Attributes panel: renders current attribute values and unspent points; shows per-attribute + and - buttons.
  - Implemented adjustAttribute(ctx, name, delta) to modify attributes with pool checks, clamp values, and refresh UI.
  - Wired attribute buttons to on-click handlers; show() rebuilds and wires up the attribute UI elements.
  - Added helper wireAttributeButtons to attach events to dynamic attribute controls.

- ui/shop_panel.js
  - Updated loot price estimates in sells list: prefer window.ShopService.getSellPrice(ctx, _shopRef, it) when available; otherwise fallback to existing calculation path.
  - This ensures CHA-based sell prices are surfaced in the UI where supported.

- General notes
  - Safety: many new paths are wrapped in try/catch to avoid breaking existing flows if data is missing.
  - UI/nudges: The attribute system is designed to be opt-in visually first, with non-destructive calculations that can be disabled if needed.
  - Balance implications: Luck provides up to +20% equipment drop bonus; CHA affects buy discounts up to 40% off and sell gains up to 30%; STR grants a small attack bonus; attribute points grant leveling-time progression.

Deployment considerations:
- Build and test flows should cover: loot drop rates, combat calculations (attack/STR bonus), shop pricing displays, and the attribute allocation UI.
- Ensure that existing save data without new fields gracefully defaults to safe values (handled by normalization and try/catch guards).
- If there are unit/UI tests, add tests for: getSellPrice correctness, finalEquipChance calculation with various LCK values, and attribute point allocation logic.

---

> This pull request was co-created with Cosine Genie

Original Task: [Roguelike_whit_world/gj977j3m0yce](https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/gj977j3m0yce)
Author: zakker111
