### PR TITLE
Update .gitignore to exclude node_modules, dist, and .vite for deployment

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/.gitignore
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.vite/


### PR DESCRIPTION
Adds node_modules/, dist/, and .vite/ to .gitignore to prevent committing dependencies and build artifacts. This helps ensure the project deploys cleanly by avoiding large or environment-specific files and reduces potential deployment errors. No code changes; this PR only updates ignore rules.

https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/3nx5jyz0amjy
https://cosine.sh/gh/zakker111/Roguelike_whit_world/pull/138
Author: zakker111