### PR TITLE
Update .gitignore to exclude node_modules, dist, and .vite build outputs

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/.gitignore
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.vite/


### PR DESCRIPTION
Adds common ignore patterns to .gitignore: node_modules/, dist/, and .vite/. This prevents committing dependencies and build artifacts, reduces repository noise, and helps prevent potential issues related to tracking generated files during development.

https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/97ka2tmx9nj5
https://cosine.sh/gh/zakker111/Roguelike_whit_world/pull/139
Author: zakker111