### PR TITLE
Improve upstream fetch resilience and actionable errors: validate AI ctx, add fetch retry/backoff, and expand tests

### DIFF
--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/ai/ai.js
@@ -64,6 +64,28 @@ export function enemiesAct(ctx) {
       return;
     }
   } catch (_) {}
+
+  // Validate required ctx shape early so failures are actionable.
+  if (!ctx || typeof ctx !== "object") return;
+  const missing = [];
+  if (!ctx.player || typeof ctx.player !== "object") missing.push("player");
+  if (!Array.isArray(ctx.enemies)) missing.push("enemies[]");
+  if (!Array.isArray(ctx.map) || !Array.isArray(ctx.map[0])) missing.push("map[][]");
+  if (!ctx.TILES || typeof ctx.TILES !== "object") missing.push("TILES");
+  if (typeof ctx.inBounds !== "function") missing.push("inBounds(x,y)");
+  if (typeof ctx.isWalkable !== "function") missing.push("isWalkable(x,y)");
+  if (missing.length) {
+    try {
+      if (!ctx._aiMissingCtxWarned) {
+        ctx._aiMissingCtxWarned = true;
+        const msg = "[AI] enemiesAct: missing required ctx fields: " + missing.join(", ");
+        if (typeof ctx.log === "function") ctx.log(msg, "warn");
+        else if (typeof console !== "undefined" && console.warn) console.warn(msg);
+      }
+    } catch (_) {}
+    return;
+  }
+
   const { player, enemies } = ctx;
   const U = (ctx && ctx.utils) ? ctx.utils : null;
   // Local RNG value helper: RNGUtils or ctx.rng; deterministic 0.5 when unavailable

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/data/loader.js
@@ -70,7 +70,11 @@ const DATA_FILES = {
   towerThemes: "data/worldgen/tower_themes.json"
 };
 
-function fetchJson(url) {
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, Math.max(0, ms | 0)));
+}
+
+async function fetchJson(url) {
   // Append version query param to avoid CDN caching stale JSON across deploys
   function withVer(u) {
     try {
@@ -81,46 +85,87 @@ function fetchJson(url) {
       return u + (hasQuery ? "&" : "?") + "v=" + encodeURIComponent(ver);
     } catch (_) { return u; }
   }
+
+  function isRetryable(err) {
+    const st = err && typeof err.status === "number" ? err.status : null;
+    if (st === 408 || st === 425 || st === 429) return true;
+    if (st != null && st >= 500 && st <= 599) return true;
+    try {
+      if (err && err.name === "AbortError") return true;
+    } catch (_) {}
+    try {
+      // Browsers throw TypeError for network errors (CORS, offline, DNS, etc.)
+      if (err instanceof TypeError) return true;
+    } catch (_) {}
+    return false;
+  }
+
+  function backoffMs(attempt) {
+    // Exponential backoff with small jitter, capped.
+    const base = 250;
+    const cap = 2500;
+    const exp = Math.min(cap, base * Math.pow(2, attempt));
+    const jitter = Math.floor(Math.random() * 120);
+    return Math.min(cap, exp + jitter);
+  }
+
   const url2 = withVer(url);
+  const RETRIES = 2;
 
-  // Guard against pathological network stalls by applying a per-request timeout.
-  // Use a generous timeout so slow connections still load full data; this mainly
-  // protects against truly hung requests.
-  let controller = null;
-  let timeoutId = null;
-  try {
-    if (typeof AbortController !== "undefined") {
-      controller = new AbortController();
-      const TIMEOUT_MS = 30000; // 30s to avoid false timeouts on slow networks
-      timeoutId = setTimeout(() => {
-        try { controller.abort(); } catch (_) {}
-      }, TIMEOUT_MS);
-    }
-  } catch (_) {}
+  for (let attempt = 0; attempt <= RETRIES; attempt++) {
+    // Guard against pathological network stalls by applying a per-attempt timeout.
+    // Use a generous timeout so slow connections still load full data; this mainly
+    // protects against truly hung requests.
+    let controller = null;
+    let timeoutId = null;
+    try {
+      if (typeof AbortController !== "undefined") {
+        controller = new AbortController();
+        const TIMEOUT_MS = 30000; // 30s to avoid false timeouts on slow networks
+        timeoutId = setTimeout(() => {
+          try { controller.abort(); } catch (_) {}
+        }, TIMEOUT_MS);
+      }
+    } catch (_) {}
 
-  const opts = controller ? { cache: "no-cache", signal: controller.signal } : { cache: "no-cache" };
-  return fetch(url2, opts)
-    .then(r => {
-      if (!r.ok) throw new Error("HTTP " + r.status + " for " + url2);
-      return r.json();
-    })
-    .catch(e => {
-      // Log a lightweight warning but let callers decide how to handle the failure.
+    const opts = controller ? { cache: "no-cache", signal: controller.signal } : { cache: "no-cache" };
+
+    try {
+      const r = await fetch(url2, opts);
+      if (!r.ok) {
+        const err = new Error("HTTP " + r.status + " for " + url2);
+        err.status = r.status;
+        throw err;
+      }
+      return await r.json();
+    } catch (e) {
+      const willRetry = (attempt < RETRIES) && isRetryable(e);
+      const delay = willRetry ? backoffMs(attempt) : 0;
+
       try {
-        const msg = "[GameData] fetch failed for " + url2 + ": " + (e && e.message ? e.message : String(e));
+        const detail = (e && e.message) ? e.message : String(e);
+        const suffix = willRetry
+          ? ` (retry ${attempt + 1}/${RETRIES} in ${delay}ms)`
+          : "";
+        const msg = "[GameData] fetch failed for " + url2 + ": " + detail + suffix;
         if (typeof window !== "undefined" && window.Logger && typeof window.Logger.log === "function") {
           window.Logger.log(msg, "warn");
         } else if (typeof console !== "undefined" && console.warn) {
           console.warn(msg);
         }
       } catch (_) {}
-      throw e;
-    })
-    .finally(() => {
+
+      if (!willRetry) throw e;
+      await sleep(delay);
+    } finally {
       if (timeoutId != null) {
         try { clearTimeout(timeoutId); } catch (_) {}
       }
-    });
+    }
+  }
+
+  // Unreachable, but keeps flow explicit.
+  throw new Error("[GameData] fetchJson exhausted retries for " + url2);
 }
 
 export const GameData = {
@@ -459,9 +504,20 @@ GameData.ready = (async function loadAll() {
     } catch (_) {}
 
     // If any registry failed to load, modules will use internal fallbacks.
-    if (!GameData.items || !GameData.enemies || !GameData.npcs || !GameData.consumables || !GameData.town || !GameData.flavor || !GameData.tiles || !GameData.encounters) {
-      logNotice("Some registries failed to load; modules will use internal fallbacks.");
-    }
+    (function logMissingRegistries() {
+      const missing = [];
+      if (!GameData.items) missing.push("items");
+      if (!GameData.enemies) missing.push("enemies");
+      if (!GameData.npcs) missing.push("npcs");
+      if (!GameData.consumables) missing.push("consumables");
+      if (!GameData.town) missing.push("town");
+      if (!GameData.flavor) missing.push("flavor");
+      if (!GameData.tiles) missing.push("tiles");
+      if (!GameData.encounters) missing.push("encounters");
+      if (missing.length) {
+        logNotice("Some registries failed to load: " + missing.join(", ") + "; modules will use internal fallbacks.");
+      }
+    })();
 
     // Notify BootMonitor (if present) that data loading has finished.
     try {

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/smoketest/runner/runner.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/smoketest/runner/runner.js
@@ -344,6 +344,7 @@
       if (name === "determinism") return S.Determinism && S.Determinism.run;
       if (name === "encounters") return (S.encounters && S.encounters.run) || (S.Encounters && S.Encounters.run);
       if (name === "api") return S.API && S.API.run;
+      if (name === "gamedata_retry") return S.gamedata_retry && S.gamedata_retry.run;
       if (name === "town_flows") return S.Town && S.Town.Flows && S.Town.Flows.run;
       if (name === "skeleton_key_chest") return S.skeleton_key_chest && S.skeleton_key_chest.run;
       if (name === "gm_mechanic_hints") return S.GMMechanicHints && S.GMMechanicHints.run;
@@ -1190,6 +1191,7 @@
         determinism: S.Determinism && S.Determinism.run,
         encounters: (S.encounters && S.encounters.run) || (S.Encounters && S.Encounters.run),
         api: S.API && S.API.run,
+        gamedata_retry: S.gamedata_retry && S.gamedata_retry.run,
         town_flows: S.Town && S.Town.Flows && S.Town.Flows.run,
         skeleton_key_chest: S.skeleton_key_chest && S.skeleton_key_chest.run,
         gm_mechanic_hints: S.GMMechanicHints && S.GMMechanicHints.run,

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/smoketest/scenarios.json
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/smoketest/scenarios.json
@@ -14,6 +14,7 @@
     { "id": "determinism", "label": "Determinism" },
     { "id": "encounters", "label": "Encounters" },
     { "id": "api", "label": "API" },
+    { "id": "gamedata_retry", "label": "GameData: Fetch retry/backoff" },
     { "id": "town_flows", "label": "Town Flows" },
     { "id": "skeleton_key_chest", "label": "Skeleton Key + Locked Chest" },
     { "id": "gm_mechanic_hints", "label": "GM: Mechanic hints (unused only)" },

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/smoketest/scenarios/gamedata_retry.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/smoketest/scenarios/gamedata_retry.js
@@ -1,0 +1,80 @@
+(function () {
+  // SmokeTest Scenario: GameData fetch retry/backoff
+  // Simulates a transient fetch failure and verifies GameData.loadPalette succeeds via fetchJson retries.
+
+  window.SmokeTest = window.SmokeTest || {};
+  window.SmokeTest.Scenarios = window.SmokeTest.Scenarios || {};
+
+  function has(fn) { try { return typeof fn === "function"; } catch (_) { return false; } }
+
+  async function run(ctx) {
+    const record = (ctx && ctx.record) || function () {};
+    const recordSkip = (ctx && ctx.recordSkip) || function () {};
+
+    const GD = (typeof window !== "undefined" ? window.GameData : null);
+    if (!GD || !GD.ready || !has(GD.loadPalette)) {
+      recordSkip("GameData retry skipped (GameData/loadPalette not available)");
+      return true;
+    }
+
+    try { await GD.ready; } catch (_) {}
+
+    const origFetch = (typeof window !== "undefined" ? window.fetch : null);
+    if (!has(origFetch)) {
+      recordSkip("GameData retry skipped (window.fetch not available)");
+      return true;
+    }
+
+    let paletteCalls = 0;
+    let injectedFail = 0;
+    const prevPalette = (function () {
+      try {
+        const v = (typeof localStorage !== "undefined" && localStorage) ? (localStorage.getItem("PALETTE") || "default") : "default";
+        return String(v || "default");
+      } catch (_) {
+        return "default";
+      }
+    })();
+
+    function shouldIntercept(url) {
+      try {
+        const s = String(url || "");
+        return s.indexOf("data/world/palette_alt.json") !== -1;
+      } catch (_) {
+        return false;
+      }
+    }
+
+    try {
+      window.fetch = function (url, opts) {
+        if (shouldIntercept(url)) {
+          paletteCalls += 1;
+          if (paletteCalls === 1) {
+            injectedFail += 1;
+            return Promise.reject(new TypeError("smoketest injected network failure"));
+          }
+        }
+        return origFetch(url, opts);
+      };
+
+      const ok = await GD.loadPalette("alt");
+      record(!!ok, "GameData.loadPalette('alt') succeeds after transient fetch failure");
+      record(injectedFail === 1, "GameData retry: injected failure hit exactly once");
+      record(paletteCalls >= 2, "GameData retry: palette fetch attempted at least twice");
+    } catch (e) {
+      record(false, "GameData retry scenario failed: " + (e && e.message ? e.message : String(e)));
+    } finally {
+      try { window.fetch = origFetch; } catch (_) {}
+      try {
+        // Restore previous palette selection so other scenarios aren't affected.
+        if (prevPalette && prevPalette !== "alt" && has(GD.loadPalette)) {
+          await GD.loadPalette(prevPalette);
+        }
+      } catch (_) {}
+    }
+
+    return true;
+  }
+
+  window.SmokeTest.Scenarios.gamedata_retry = { run };
+})();

--- a/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/src/main.js
+++ b/ROguelike 3_10_2025 filut jarjestyksessa luultavasti vikaa/src/main.js
@@ -134,6 +134,7 @@ document.addEventListener('DOMContentLoaded', function () {
         '/smoketest/scenarios/town_diagnostics.js',
         '/smoketest/scenarios/api.js',
         '/smoketest/scenarios/encounters.js',
+        '/smoketest/scenarios/gamedata_retry.js',
         '/smoketest/scenarios/gm_mechanic_hints.js',
         '/smoketest/scenarios/gm_intent_decisions.js',
         '/smoketest/scenarios/gm_seed_reset.js',


### PR DESCRIPTION
This PR enhances error visibility and resilience when interacting with upstream providers, and adds tests to verify the new behavior. Key changes:

- AI context validation: Enemies action now validates the required ctx shape early and logs a clear warning if fields are missing (player, enemies[], map[][], TILES, inBounds, isWalkable). This makes failures actionable instead of failing deep inside the logic.
- Upstream fetch retry/backoff: fetchJson now supports retries with exponential backoff, a per-attempt timeout, and retryable error detection (HTTP status ranges, AbortError, network TypeError). Successful responses are returned; failed attempts retry up to a configurable limit with jitter and then fail with a helpful log.
- Better registry load logging: After data loading, missing registries are reported in a single notice to aid debugging when data registries fail to load.
- GameData smoke test: Added a new scenario (gamedata_retry) to simulate a transient fetch failure and ensure the retry path succeeds, validating the new backoff/retry logic.
- Smoke test integration: The new gamedata_retry scenario is wired into the smoke test suite and the loader to ensure coverage during runs.

How this solves the issue: The message There was an error with an upstream provider can stem from transient network errors or poorly surfaced missing context. The new early ctx validation provides immediate, actionable feedback for missing game AI context. The fetch retry/backoff prevents flaky upstream fetches from breaking data loading, reducing false negatives and downtime, while detailed logging helps diagnose issues quickly. The added test ensures the retry logic is exercised and remains reliable across changes.

https://cosine.sh/6tvrjnmck4r1/Roguelike_whit_world/task/inna5iua50k1
https://cosine.sh/gh/zakker111/Roguelike_whit_world/pull/144
Author: zakker111